### PR TITLE
feat: Add block source metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9310,6 +9310,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-evm-ethereum",
+ "reth-metrics",
  "reth-network",
  "reth-network-api",
  "reth-network-p2p",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ reth-trie-db = { git = "https://github.com/sprites0/reth", rev = "a690ef25b56039
 reth-codecs = { git = "https://github.com/sprites0/reth", rev = "a690ef25b56039195e7e4a4abd01c78aedcc73fb" }
 reth-transaction-pool = { git = "https://github.com/sprites0/reth", rev = "a690ef25b56039195e7e4a4abd01c78aedcc73fb" }
 reth-stages-types = { git = "https://github.com/sprites0/reth", rev = "a690ef25b56039195e7e4a4abd01c78aedcc73fb" }
+reth-metrics = { git = "https://github.com/sprites0/reth", rev = "a690ef25b56039195e7e4a4abd01c78aedcc73fb" }
 revm = { version = "28.0.1", default-features = false }
 
 # alloy dependencies


### PR DESCRIPTION
This PR adds:

- `block_source.s3.{polling_attempt, fetched}`
- `block_source.local.{polling_attempt, fetched}`
- `block_source.hl_node.{fetched_from_hl_node, fetched_from_fallback}`

Resolves #58 