### PR TITLE
feat(rpc): add HlBlockPrecompile rpc API

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use reth_hl::{
     chainspec::{parser::HlChainSpecParser, HlChainSpec},
     node::{
         cli::{Cli, HlNodeArgs},
+        rpc::precompile::{HlBlockPrecompileApiServer, HlBlockPrecompileExt},
         storage::tables::Tables,
         HlNode,
     },
@@ -71,6 +72,10 @@ fn main() -> eyre::Result<()> {
                         ctx.modules.remove_method_from_configured("eth_getProof");
                         info!("eth_getProof is disabled by default");
                     }
+
+                    ctx.modules.merge_configured(
+                        HlBlockPrecompileExt::new(ctx.registry.eth_api().clone()).into_rpc(),
+                    )?;
 
                     Ok(())
                 })

--- a/src/node/rpc/call.rs
+++ b/src/node/rpc/call.rs
@@ -61,7 +61,7 @@ where
         DB: Database<Error = ProviderError> + fmt::Debug,
     {
         let block_number = evm_env.block_env().number;
-        let hl_extras = self.get_hl_extras(block_number.try_into().unwrap())?;
+        let hl_extras = self.get_hl_extras(block_number.to::<u64>().into())?;
 
         let mut evm = self.evm_config().evm_with_env(db, evm_env);
         apply_precompiles(&mut evm, &hl_extras);
@@ -82,7 +82,7 @@ where
         I: InspectorFor<Self::Evm, DB>,
     {
         let block_number = evm_env.block_env().number;
-        let hl_extras = self.get_hl_extras(block_number.try_into().unwrap())?;
+        let hl_extras = self.get_hl_extras(block_number.to::<u64>().into())?;
 
         let mut evm = self.evm_config().evm_with_env_and_inspector(db, evm_env, inspector);
         apply_precompiles(&mut evm, &hl_extras);
@@ -103,7 +103,7 @@ where
         I: IntoIterator<Item = Recovered<&'a ProviderTx<Self::Provider>>>,
     {
         let block_number = evm_env.block_env().number;
-        let hl_extras = self.get_hl_extras(block_number.try_into().unwrap())?;
+        let hl_extras = self.get_hl_extras(block_number.to::<u64>().into())?;
 
         let mut evm = self.evm_config().evm_with_env(db, evm_env);
         apply_precompiles(&mut evm, &hl_extras);

--- a/src/node/rpc/estimate.rs
+++ b/src/node/rpc/estimate.rs
@@ -98,7 +98,7 @@ where
         tx_env.set_gas_limit(tx_env.gas_limit().min(highest_gas_limit));
 
         let block_number = evm_env.block_env().number;
-        let hl_extras = self.get_hl_extras(block_number.try_into().unwrap())?;
+        let hl_extras = self.get_hl_extras(block_number.to::<u64>().into())?;
 
         let mut evm = self.evm_config().evm_with_env(&mut db, evm_env);
         apply_precompiles(&mut evm, &hl_extras);

--- a/src/node/rpc/mod.rs
+++ b/src/node/rpc/mod.rs
@@ -3,6 +3,7 @@ use crate::{
     node::{evm::apply_precompiles, types::HlExtras},
     HlBlock, HlPrimitives,
 };
+use alloy_eips::BlockHashOrNumber;
 use alloy_evm::Evm;
 use alloy_network::Ethereum;
 use alloy_primitives::U256;
@@ -233,7 +234,7 @@ where
         I: InspectorFor<Self::Evm, DB>,
     {
         let block_number = evm_env.block_env().number;
-        let hl_extras = self.get_hl_extras(block_number.try_into().unwrap())?;
+        let hl_extras = self.get_hl_extras(block_number.to::<u64>().into())?;
 
         let mut evm = self.evm_config().evm_with_env_and_inspector(db, evm_env, inspector);
         apply_precompiles(&mut evm, &hl_extras);
@@ -246,10 +247,10 @@ where
     N: HlRpcNodeCore,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError>,
 {
-    fn get_hl_extras(&self, block_number: u64) -> Result<HlExtras, ProviderError> {
+    fn get_hl_extras(&self, block: BlockHashOrNumber) -> Result<HlExtras, ProviderError> {
         Ok(self
             .provider()
-            .block_by_number(block_number)?
+            .block(block)?
             .map(|block| HlExtras {
                 read_precompile_calls: block.body.read_precompile_calls.clone(),
                 highest_precompile_address: block.body.highest_precompile_address,

--- a/src/node/rpc/mod.rs
+++ b/src/node/rpc/mod.rs
@@ -43,6 +43,7 @@ mod block;
 mod call;
 pub mod engine_api;
 mod estimate;
+pub mod precompile;
 mod transaction;
 
 pub trait HlRpcNodeCore: RpcNodeCore<Primitives: NodePrimitives<Block = HlBlock>> {}

--- a/src/node/rpc/mod.rs
+++ b/src/node/rpc/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     node::{evm::apply_precompiles, types::HlExtras},
     HlBlock, HlPrimitives,
 };
-use alloy_eips::BlockHashOrNumber;
+use alloy_eips::BlockId;
 use alloy_evm::Evm;
 use alloy_network::Ethereum;
 use alloy_primitives::U256;
@@ -27,7 +27,9 @@ use reth::{
 };
 use reth_evm::{ConfigureEvm, Database, EvmEnvFor, HaltReasonFor, InspectorFor, TxEnvFor};
 use reth_primitives::NodePrimitives;
-use reth_provider::{BlockReader, ChainSpecProvider, ProviderError, ProviderHeader, ProviderTx};
+use reth_provider::{
+    BlockReaderIdExt, ChainSpecProvider, ProviderError, ProviderHeader, ProviderTx,
+};
 use reth_rpc::RpcTypes;
 use reth_rpc_eth_api::{
     helpers::{
@@ -247,10 +249,10 @@ where
     N: HlRpcNodeCore,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError>,
 {
-    fn get_hl_extras(&self, block: BlockHashOrNumber) -> Result<HlExtras, ProviderError> {
+    fn get_hl_extras(&self, block: BlockId) -> Result<HlExtras, ProviderError> {
         Ok(self
             .provider()
-            .block(block)?
+            .block_by_id(block)?
             .map(|block| HlExtras {
                 read_precompile_calls: block.body.read_precompile_calls.clone(),
                 highest_precompile_address: block.body.highest_precompile_address,

--- a/src/node/rpc/precompile.rs
+++ b/src/node/rpc/precompile.rs
@@ -1,4 +1,4 @@
-use alloy_eips::BlockHashOrNumber;
+use alloy_eips::BlockId;
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee_core::{async_trait, RpcResult};
 use reth_rpc_convert::RpcConvert;
@@ -16,7 +16,7 @@ use crate::node::{
 pub trait HlBlockPrecompileApi {
     /// Fetches precompile data for a given block.
     #[method(name = "blockPrecompileData")]
-    async fn block_precompile_data(&self, block: BlockHashOrNumber) -> RpcResult<HlExtras>;
+    async fn block_precompile_data(&self, block: BlockId) -> RpcResult<HlExtras>;
 }
 
 pub struct HlBlockPrecompileExt<N: HlRpcNodeCore, Rpc: RpcConvert> {
@@ -36,7 +36,7 @@ where
     N: HlRpcNodeCore,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError>,
 {
-    async fn block_precompile_data(&self, block: BlockHashOrNumber) -> RpcResult<HlExtras> {
+    async fn block_precompile_data(&self, block: BlockId) -> RpcResult<HlExtras> {
         trace!(target: "rpc::eth", ?block, "Serving eth_blockPrecompileData");
         let hl_extras = self.eth_api.get_hl_extras(block).map_err(|e| EthApiError::from(e))?;
         Ok(hl_extras)

--- a/src/node/rpc/precompile.rs
+++ b/src/node/rpc/precompile.rs
@@ -1,3 +1,4 @@
+use alloy_eips::BlockHashOrNumber;
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee_core::{async_trait, RpcResult};
 use reth_rpc_convert::RpcConvert;
@@ -13,9 +14,9 @@ use crate::node::{
 #[rpc(server, namespace = "eth")]
 #[async_trait]
 pub trait HlBlockPrecompileApi {
-    /// Fetches precompile data for a given block number.
+    /// Fetches precompile data for a given block.
     #[method(name = "blockPrecompileData")]
-    async fn block_precompile_data(&self, block_number: u64) -> RpcResult<HlExtras>;
+    async fn block_precompile_data(&self, block: BlockHashOrNumber) -> RpcResult<HlExtras>;
 }
 
 pub struct HlBlockPrecompileExt<N: HlRpcNodeCore, Rpc: RpcConvert> {
@@ -35,10 +36,9 @@ where
     N: HlRpcNodeCore,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError>,
 {
-    async fn block_precompile_data(&self, block_number: u64) -> RpcResult<HlExtras> {
-        trace!(target: "rpc::eth", block_number, "Serving eth_blockPrecompileData");
-        let hl_extras =
-            self.eth_api.get_hl_extras(block_number).map_err(|e| EthApiError::from(e))?;
+    async fn block_precompile_data(&self, block: BlockHashOrNumber) -> RpcResult<HlExtras> {
+        trace!(target: "rpc::eth", ?block, "Serving eth_blockPrecompileData");
+        let hl_extras = self.eth_api.get_hl_extras(block).map_err(|e| EthApiError::from(e))?;
         Ok(hl_extras)
     }
 }

--- a/src/node/rpc/precompile.rs
+++ b/src/node/rpc/precompile.rs
@@ -38,7 +38,7 @@ where
 {
     async fn block_precompile_data(&self, block: BlockId) -> RpcResult<HlExtras> {
         trace!(target: "rpc::eth", ?block, "Serving eth_blockPrecompileData");
-        let hl_extras = self.eth_api.get_hl_extras(block).map_err(|e| EthApiError::from(e))?;
+        let hl_extras = self.eth_api.get_hl_extras(block).map_err(EthApiError::from)?;
         Ok(hl_extras)
     }
 }


### PR DESCRIPTION
add a custom rpc method to the `eth` namespace: `eth_blockPrecompileData`, that returns the `HlExtras` type from a given block