### PR TITLE
feat: Add debug CLI flag to enforce latest blocks (--debug-cutoff-height)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,8 @@ fn main() -> eyre::Result<()> {
          ext: HlNodeArgs| async move {
             let default_upstream_rpc_url = builder.config().chain.official_rpc_url();
 
-            let (node, engine_handle_tx) = HlNode::new(ext.block_source_args.parse().await?);
+            let (node, engine_handle_tx) =
+                HlNode::new(ext.block_source_args.parse().await?, ext.debug_cutoff_height);
             let NodeHandle { node, node_exit_future: exit_future } = builder
                 .node(node)
                 .extend_rpc_modules(move |mut ctx| {

--- a/src/node/cli.rs
+++ b/src/node/cli.rs
@@ -35,6 +35,12 @@ pub struct HlNodeArgs {
     #[command(flatten)]
     pub block_source_args: BlockSourceArgs,
 
+    /// Debug cutoff height.
+    ///
+    /// This option is used to cut off the block import at a specific height.
+    #[arg(long, env = "DEBUG_CUTOFF_HEIGHT")]
+    pub debug_cutoff_height: Option<u64>,
+
     /// Upstream RPC URL to forward incoming transactions.
     ///
     /// Default to Hyperliquid's RPC URL when not provided (https://rpc.hyperliquid.xyz/evm).

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -49,14 +49,23 @@ pub type HlNodeAddOns<N> =
 pub struct HlNode {
     engine_handle_rx: Arc<Mutex<Option<oneshot::Receiver<ConsensusEngineHandle<HlPayloadTypes>>>>>,
     block_source_config: BlockSourceConfig,
+    debug_cutoff_height: Option<u64>,
 }
 
 impl HlNode {
     pub fn new(
         block_source_config: BlockSourceConfig,
+        debug_cutoff_height: Option<u64>,
     ) -> (Self, oneshot::Sender<ConsensusEngineHandle<HlPayloadTypes>>) {
         let (tx, rx) = oneshot::channel();
-        (Self { engine_handle_rx: Arc::new(Mutex::new(Some(rx))), block_source_config }, tx)
+        (
+            Self {
+                engine_handle_rx: Arc::new(Mutex::new(Some(rx))),
+                block_source_config,
+                debug_cutoff_height,
+            },
+            tx,
+        )
     }
 }
 
@@ -84,6 +93,7 @@ impl HlNode {
             .network(HlNetworkBuilder {
                 engine_handle_rx: self.engine_handle_rx.clone(),
                 block_source_config: self.block_source_config.clone(),
+                debug_cutoff_height: self.debug_cutoff_height,
             })
             .consensus(HlConsensusBuilder::default())
     }

--- a/src/node/network/mod.rs
+++ b/src/node/network/mod.rs
@@ -142,6 +142,8 @@ pub struct HlNetworkBuilder {
         Arc<Mutex<Option<oneshot::Receiver<ConsensusEngineHandle<HlPayloadTypes>>>>>,
 
     pub(crate) block_source_config: BlockSourceConfig,
+
+    pub(crate) debug_cutoff_height: Option<u64>,
 }
 
 impl HlNetworkBuilder {
@@ -203,6 +205,7 @@ where
         pool: Pool,
     ) -> eyre::Result<Self::Network> {
         let block_source_config = self.block_source_config.clone();
+        let debug_cutoff_height = self.debug_cutoff_height;
         let handle =
             ctx.start_network(NetworkManager::builder(self.network_config(ctx)?).await?, pool);
         let local_node_record = handle.local_node_record();
@@ -223,6 +226,7 @@ where
                 block_source_config
                     .create_cached_block_source((*chain_spec).clone(), next_block_number)
                     .await,
+                debug_cutoff_height,
             )
             .await
             .unwrap();

--- a/src/pseudo_peer/mod.rs
+++ b/src/pseudo_peer/mod.rs
@@ -37,6 +37,7 @@ pub async fn start_pseudo_peer(
     chain_spec: Arc<HlChainSpec>,
     destination_peer: String,
     block_source: BlockSourceBoxed,
+    debug_cutoff_height: Option<u64>,
 ) -> eyre::Result<()> {
     let blockhash_cache = new_blockhash_cache();
 
@@ -46,6 +47,7 @@ pub async fn start_pseudo_peer(
         destination_peer,
         block_source.clone(),
         blockhash_cache.clone(),
+        debug_cutoff_height,
     )
     .await?;
 


### PR DESCRIPTION
This is useful when syncing to specific testnet blocks. Also specifiable via `DEBUG_CUTOFF_HEIGHT` env variable.