### PR TITLE
fix: Fix typo in --local (default hl-node dir)

### DIFF
--- a/src/pseudo_peer/config.rs
+++ b/src/pseudo_peer/config.rs
@@ -46,7 +46,7 @@ impl BlockSourceConfig {
                     .expect("home dir not found")
                     .join("hl")
                     .join("data")
-                    .join("evm_blocks_and_receipts"),
+                    .join("evm_block_and_receipts"),
             },
             block_source_from_node: None,
         }


### PR DESCRIPTION
Affects `--local` which is shortcut of `--local-ingest-dir=$HOME/hl/data/evm_block_and_receipts` (typo was block[s])