### PR TITLE
fix(local-ingest-dir): Use more robust resumption for hl-node line reader, fix block number increment for reading files

### DIFF
--- a/src/addons/hl_node_compliance.rs
+++ b/src/addons/hl_node_compliance.rs
@@ -579,7 +579,7 @@ async fn adjust_transaction_receipt<Eth: EthWrapper>(
 fn system_tx_count_for_block<Eth: EthWrapper>(eth_api: &Eth, block_id: BlockId) -> usize {
     let provider = eth_api.provider();
     let block = provider.block_by_id(block_id).unwrap().unwrap();
-    
+
     block.body.transactions().iter().filter(|tx| tx.is_system_transaction()).count()
 }
 

--- a/src/node/rpc/estimate.rs
+++ b/src/node/rpc/estimate.rs
@@ -82,11 +82,12 @@ where
         let mut tx_env = self.create_txn_env(&evm_env, request, &mut db)?;
 
         let mut is_basic_transfer = false;
-        if tx_env.input().is_empty()
-            && let TxKind::Call(to) = tx_env.kind()
-                && let Ok(code) = db.db.account_code(&to) {
-                    is_basic_transfer = code.map(|code| code.is_empty()).unwrap_or(true);
-                }
+        if tx_env.input().is_empty() &&
+            let TxKind::Call(to) = tx_env.kind() &&
+            let Ok(code) = db.db.account_code(&to)
+        {
+            is_basic_transfer = code.map(|code| code.is_empty()).unwrap_or(true);
+        }
 
         if tx_env.gas_price() > 0 {
             highest_gas_limit =
@@ -105,10 +106,11 @@ where
             let mut min_tx_env = tx_env.clone();
             min_tx_env.set_gas_limit(MIN_TRANSACTION_GAS);
 
-            if let Ok(res) = evm.transact(min_tx_env).map_err(Self::Error::from_evm_err)
-                && res.result.is_success() {
-                    return Ok(U256::from(MIN_TRANSACTION_GAS));
-                }
+            if let Ok(res) = evm.transact(min_tx_env).map_err(Self::Error::from_evm_err) &&
+                res.result.is_success()
+            {
+                return Ok(U256::from(MIN_TRANSACTION_GAS));
+            }
         }
 
         trace!(target: "rpc::eth::estimate", ?tx_env, gas_limit = tx_env.gas_limit(), is_basic_transfer, "Starting gas estimation");

--- a/src/pseudo_peer/service.rs
+++ b/src/pseudo_peer/service.rs
@@ -81,10 +81,11 @@ impl BlockPoller {
             .await
             .ok_or(eyre::eyre!("Failed to find latest block number"))?;
 
-        if let Some(debug_cutoff_height) = debug_cutoff_height
-            && next_block_number > debug_cutoff_height {
-                next_block_number = debug_cutoff_height;
-            }
+        if let Some(debug_cutoff_height) = debug_cutoff_height &&
+            next_block_number > debug_cutoff_height
+        {
+            next_block_number = debug_cutoff_height;
+        }
 
         loop {
             match block_source.collect_block(next_block_number).await {

--- a/src/pseudo_peer/sources/hl_node/cache.rs
+++ b/src/pseudo_peer/sources/hl_node/cache.rs
@@ -27,7 +27,7 @@ impl LocalBlocksCache {
     }
 
     pub fn get_block(&mut self, height: u64) -> Option<BlockAndReceipts> {
-        self.cache.remove(&height)
+        self.cache.get(&height).cloned()
     }
 
     pub fn get_path_for_height(&self, height: u64) -> Option<PathBuf> {

--- a/src/pseudo_peer/sources/hl_node/scan.rs
+++ b/src/pseudo_peer/sources/hl_node/scan.rs
@@ -2,7 +2,7 @@ use crate::node::types::{BlockAndReceipts, EvmBlock};
 use serde::{Deserialize, Serialize};
 use std::{
     fs::File,
-    io::{BufRead, BufReader},
+    io::{BufRead, BufReader, Seek, SeekFrom},
     ops::RangeInclusive,
     path::{Path, PathBuf},
 };
@@ -18,12 +18,64 @@ pub struct ScanResult {
     pub new_block_ranges: Vec<RangeInclusive<u64>>,
 }
 
+#[derive(Debug, Clone)]
 pub struct ScanOptions {
     pub start_height: u64,
     pub only_load_ranges: bool,
 }
 
 pub struct Scanner;
+
+/// Stream for sequentially reading lines from a file.
+///
+/// This struct allows sequential iteration over lines over [Self::next] method.
+/// It is resilient to cases where the line producer process is interrupted while writing:
+/// - If a line is incomplete but still ends with a line ending, it is skipped: later, the fallback
+///   block source will be used to retrieve the missing block.
+/// - If a line does not end with a newline (i.e., the write was incomplete), the method returns
+///   `None` to break out of the loop and avoid reading partial data.
+/// - If a temporary I/O error occurs, the stream exits the loop without rewinding the cursor, which
+///   will result in skipping ahead to the next unread bytes.
+pub struct LineStream {
+    path: PathBuf,
+    reader: BufReader<File>,
+}
+
+impl LineStream {
+    pub fn from_path(path: &Path) -> std::io::Result<Self> {
+        let reader = BufReader::with_capacity(1024 * 1024, File::open(path)?);
+        Ok(Self { path: path.to_path_buf(), reader })
+    }
+
+    pub fn next(&mut self) -> Option<String> {
+        let mut line_buffer = vec![];
+        let Ok(size) = self.reader.read_until(b'\n', &mut line_buffer) else {
+            // Temporary I/O error; restart the loop
+            return None;
+        };
+
+        // Now cursor is right after the end of the line
+        // On UTF-8 error, skip the line
+        let Ok(mut line) = String::from_utf8(line_buffer) else {
+            return Some(String::new());
+        };
+
+        // If line is not completed yet, return None so that we can break the loop
+        if line.ends_with('\n') {
+            if line.ends_with('\r') {
+                line.pop();
+            }
+            line.pop();
+            return Some(line);
+        }
+
+        // info!("Line is not completed yet: {}", line);
+        if size != 0 {
+            self.reader.seek(SeekFrom::Current(-(size as i64))).unwrap();
+        }
+        None
+    }
+}
 
 impl Scanner {
     pub fn line_to_evm_block(line: &str) -> serde_json::Result<(BlockAndReceipts, u64)> {
@@ -35,31 +87,20 @@ impl Scanner {
         Ok((parsed_block, height))
     }
 
-    pub fn scan_hour_file(path: &Path, last_line: &mut usize, options: ScanOptions) -> ScanResult {
-        let lines: Vec<String> =
-            BufReader::new(File::open(path).expect("Failed to open hour file"))
-                .lines()
-                .collect::<Result<_, _>>()
-                .unwrap();
-        let skip = if *last_line == 0 { 0 } else { *last_line - 1 };
+    pub fn scan_hour_file(line_stream: &mut LineStream, options: ScanOptions) -> ScanResult {
         let mut new_blocks = Vec::new();
         let mut last_height = options.start_height;
         let mut block_ranges = Vec::new();
         let mut current_range: Option<(u64, u64)> = None;
 
-        for (line_idx, line) in lines.iter().enumerate().skip(skip) {
-            if line_idx < *last_line || line.trim().is_empty() {
-                continue;
-            }
-
-            match Self::line_to_evm_block(line) {
+        while let Some(line) = line_stream.next() {
+            match Self::line_to_evm_block(&line) {
                 Ok((parsed_block, height)) => {
                     if height >= options.start_height {
                         last_height = last_height.max(height);
                         if !options.only_load_ranges {
                             new_blocks.push(parsed_block);
                         }
-                        *last_line = line_idx;
                     }
 
                     match current_range {
@@ -74,7 +115,7 @@ impl Scanner {
                         }
                     }
                 }
-                Err(_) => warn!("Failed to parse line: {}...", line.get(0..50).unwrap_or(line)),
+                Err(_) => warn!("Failed to parse line: {}...", line.get(0..50).unwrap_or(&line)),
             }
         }
 
@@ -82,7 +123,7 @@ impl Scanner {
             block_ranges.push(start..=end);
         }
         ScanResult {
-            path: path.to_path_buf(),
+            path: line_stream.path.clone(),
             next_expected_height: last_height + 1,
             new_blocks,
             new_block_ranges: block_ranges,

--- a/src/pseudo_peer/sources/hl_node/scan.rs
+++ b/src/pseudo_peer/sources/hl_node/scan.rs
@@ -18,7 +18,6 @@ pub struct ScanResult {
     pub new_block_ranges: Vec<RangeInclusive<u64>>,
 }
 
-#[derive(Debug, Clone)]
 pub struct ScanOptions {
     pub start_height: u64,
     pub only_load_ranges: bool,
@@ -122,9 +121,10 @@ impl Scanner {
         if let Some((start, end)) = current_range {
             block_ranges.push(start..=end);
         }
+
         ScanResult {
             path: line_stream.path.clone(),
-            next_expected_height: last_height + 1,
+            next_expected_height: last_height + current_range.is_some() as u64,
             new_blocks,
             new_block_ranges: block_ranges,
         }


### PR DESCRIPTION
This tries to resolve #75 
Related: #70 

- Prevent unnecessary read by using byte offset 0fd4b7943f31447ad19f3c5f7080307ac1d5d66d
- Increase cache hit when backfilling b8bae7cde975cfd2daba2c5162a72de2277bae5b
- Fix typo that prevented ingest loop from working 12f366573e34fcbf79854ba3a613dd56def74d32
- Add metrics: `file_read_triggered` 4d83b687d4eb761d61475dee693c7c0e9fba7ca7

Also it uses BufReader with 1MB buffer. BufReader is not constructed often; it's reused for one hour. When file read is triggered, 1MB buffer also helps because it tries to read the whole file much faster.

Many things were off, and hopefully this fixes the issues around --local-ingest-dir. Regardless of this fixing the linked issue or not, this should be merged.