### PR TITLE
fix: Fix --debug-cutoff-height semantics

### DIFF
--- a/src/pseudo_peer/service.rs
+++ b/src/pseudo_peer/service.rs
@@ -81,13 +81,13 @@ impl BlockPoller {
             .await
             .ok_or(eyre::eyre!("Failed to find latest block number"))?;
 
-        if let Some(debug_cutoff_height) = debug_cutoff_height &&
-            next_block_number > debug_cutoff_height
-        {
-            next_block_number = debug_cutoff_height;
-        }
-
         loop {
+            if let Some(debug_cutoff_height) = debug_cutoff_height
+                && next_block_number > debug_cutoff_height
+            {
+                next_block_number = debug_cutoff_height;
+            }
+
             match block_source.collect_block(next_block_number).await {
                 Ok(block) => {
                     block_tx.send((next_block_number, block)).await?;


### PR DESCRIPTION
NOTE: This is a debug feature not on by default.

The original intention of it was limiting the highest block number. But it was instead enforcing the starting block number for fetching, leading to block progression instead of stopping at the specified block number.