### PR TITLE
fix: Prevent #89 from overriding --hl-node-compliant subscriptions

### DIFF
--- a/src/addons/hl_node_compliance.rs
+++ b/src/addons/hl_node_compliance.rs
@@ -347,8 +347,10 @@ where
                     pubsub.log_stream(filter).filter_map(|log| adjust_log::<Eth>(log, &provider)),
                 )
                 .await;
-            } else {
+            } else if kind == SubscriptionKind::NewHeads {
                 let _ = pipe_from_stream(sink, new_headers_stream::<Eth>(&provider)).await;
+            } else {
+                let _ = pubsub.handle_accepted(sink, kind, params).await;
             }
         }));
         Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,16 +63,6 @@ fn main() -> eyre::Result<()> {
                         info!("Call/gas estimation will be forwarded to {}", upstream_rpc_url);
                     }
 
-                    if ext.hl_node_compliant {
-                        install_hl_node_compliance(&mut ctx)?;
-                        info!("hl-node compliant mode enabled");
-                    }
-
-                    if !ext.experimental_eth_get_proof {
-                        ctx.modules.remove_method_from_configured("eth_getProof");
-                        info!("eth_getProof is disabled by default");
-                    }
-
                     // This is a temporary workaround to fix the issue with custom headers
                     // affects `eth_subscribe[type=newHeads]`
                     ctx.modules.replace_configured(
@@ -83,6 +73,16 @@ fn main() -> eyre::Result<()> {
                         )
                         .into_rpc(),
                     )?;
+
+                    if ext.hl_node_compliant {
+                        install_hl_node_compliance(&mut ctx)?;
+                        info!("hl-node compliant mode enabled");
+                    }
+
+                    if !ext.experimental_eth_get_proof {
+                        ctx.modules.remove_method_from_configured("eth_getProof");
+                        info!("eth_getProof is disabled by default");
+                    }
 
                     ctx.modules.merge_configured(
                         HlBlockPrecompileExt::new(ctx.registry.eth_api().clone()).into_rpc(),


### PR DESCRIPTION
## Impact

Fix for `--hl-node-compliant` mode on the latest version (**nb-20251011**).
Not affected if this flag is **not** used.

**Affected RPC:** `eth_subscribe[type=logs]` (WebSocket) when running with `--hl-node-compliant`.

## Details

Regression from #89 caused `eth_subscribe` to be overridden after the `--hl-node-compliant` logic, resulting in logs from **system transactions** being returned.

This patch also addresses a previously unreachable bug (6c3ed63c3c341ffff5c14c913e26f40f262a6543), which becomes reachable after the main fix.