### PR TITLE
fix: Adjust transaction parser

### DIFF
--- a/src/node/types/reth_compat.rs
+++ b/src/node/types/reth_compat.rs
@@ -1,5 +1,4 @@
 //! Copy of reth codebase to preserve serialization compatibility
-use crate::chainspec::TESTNET_CHAIN_ID;
 use alloy_consensus::{Header, Signed, TxEip1559, TxEip2930, TxEip4844, TxEip7702, TxLegacy};
 use alloy_primitives::{Address, BlockHash, Signature, TxKind, U256};
 use reth_primitives::TransactionSigned as RethTxSigned;
@@ -118,11 +117,8 @@ impl SealedBlock {
         receipts: Vec<LegacyReceipt>,
         chain_id: u64,
     ) -> HlBlock {
-        // NOTE: Filter out system transactions that may be rejected by the EVM (tracked by #97,
-        // testnet only).
-        if chain_id == TESTNET_CHAIN_ID {
-            system_txs = system_txs.into_iter().filter(|tx| tx.receipt.is_some()).collect();
-        }
+        // NOTE: These types of transactions are tracked at #97.
+        system_txs.retain(|tx| tx.receipt.is_some());
 
         let mut merged_txs = vec![];
         merged_txs.extend(system_txs.iter().map(|tx| system_tx_to_reth_transaction(tx, chain_id)));


### PR DESCRIPTION
Based on observation on all blocks in both networks (mainnet: 1-latest, testnet: 34M-latest)

Methodology: used https://github.com/sprites0/evm-downloader

Tracked by #97