### PR TITLE
feat: Default to localhost-only network, add --allow-network-overrides

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -39,8 +39,11 @@ fn main() -> eyre::Result<()> {
          ext: HlNodeArgs| async move {
             let default_upstream_rpc_url = builder.config().chain.official_rpc_url();
 
-            let (node, engine_handle_tx) =
-                HlNode::new(ext.block_source_args.parse().await?, ext.debug_cutoff_height);
+            let (node, engine_handle_tx) = HlNode::new(
+                ext.block_source_args.parse().await?,
+                ext.debug_cutoff_height,
+                ext.allow_network_overrides,
+            );
             let NodeHandle { node, node_exit_future: exit_future } = builder
                 .node(node)
                 .extend_rpc_modules(move |mut ctx| {

--- a/src/node/cli.rs
+++ b/src/node/cli.rs
@@ -82,6 +82,13 @@ pub struct HlNodeArgs {
     /// * Refers to the Merkle trie used for eth_getProof and state root, not actual state values.
     #[arg(long, env = "EXPERIMENTAL_ETH_GET_PROOF")]
     pub experimental_eth_get_proof: bool,
+
+    /// Allow network configuration overrides from CLI.
+    ///
+    /// When enabled, network settings (discovery_addr, listener_addr, dns_discovery, nat)
+    /// will be taken from CLI arguments instead of being hardcoded to localhost-only defaults.
+    #[arg(long, env = "ALLOW_NETWORK_OVERRIDES")]
+    pub allow_network_overrides: bool,
 }
 
 /// The main reth_hl cli interface.

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -51,12 +51,14 @@ pub struct HlNode {
     engine_handle_rx: Arc<Mutex<Option<oneshot::Receiver<ConsensusEngineHandle<HlPayloadTypes>>>>>,
     block_source_config: BlockSourceConfig,
     debug_cutoff_height: Option<u64>,
+    allow_network_overrides: bool,
 }
 
 impl HlNode {
     pub fn new(
         block_source_config: BlockSourceConfig,
         debug_cutoff_height: Option<u64>,
+        allow_network_overrides: bool,
     ) -> (Self, oneshot::Sender<ConsensusEngineHandle<HlPayloadTypes>>) {
         let (tx, rx) = oneshot::channel();
         (
@@ -64,6 +66,7 @@ impl HlNode {
                 engine_handle_rx: Arc::new(Mutex::new(Some(rx))),
                 block_source_config,
                 debug_cutoff_height,
+                allow_network_overrides,
             },
             tx,
         )
@@ -95,6 +98,7 @@ impl HlNode {
                 engine_handle_rx: self.engine_handle_rx.clone(),
                 block_source_config: self.block_source_config.clone(),
                 debug_cutoff_height: self.debug_cutoff_height,
+                allow_network_overrides: self.allow_network_overrides,
             })
             .consensus(HlConsensusBuilder::default())
     }


### PR DESCRIPTION
Network now defaults to localhost-only (local discovery/listener, no DNS/NAT). Use --allow-network-overrides flag to restore CLI-based network configuration.