### PR TITLE
feat(rpc): new eth_getBlockReceiptsWithSystemTx endpoint

### DIFF
--- a/src/addons/hl_node_compliance.rs
+++ b/src/addons/hl_node_compliance.rs
@@ -31,11 +31,19 @@ use reth_rpc_eth_api::{
     RpcTransaction, helpers::EthBlocks, transaction::ConvertReceiptInput,
 };
 use reth_rpc_eth_types::EthApiError;
+use serde::{Deserialize, Serialize};
 use std::{marker::PhantomData, sync::Arc};
 use tokio_stream::StreamExt;
 use tracing::{Instrument, trace};
 
 use crate::addons::utils::{EthWrapper, new_headers_stream, pipe_from_stream};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BlockReceiptsWithSystemTx<R> {
+    pub receipts: Vec<R>,
+    pub system_tx_receipts: Vec<R>,
+}
 
 #[rpc(server, namespace = "eth")]
 #[async_trait]
@@ -402,7 +410,10 @@ pub trait EthBlockApi<B: RpcObject, R: RpcObject> {
 
     /// Returns all transaction receipts for a given block, including system transactions.
     #[method(name = "getBlockReceiptsWithSystemTx")]
-    async fn block_receipts_with_system_tx(&self, block_id: BlockId) -> RpcResult<Option<Vec<R>>>;
+    async fn block_receipts_with_system_tx(
+        &self,
+        block_id: BlockId,
+    ) -> RpcResult<Option<BlockReceiptsWithSystemTx<R>>>;
 
     #[method(name = "getBlockTransactionCountByHash")]
     async fn block_transaction_count_by_hash(&self, hash: B256) -> RpcResult<Option<U256>>;
@@ -510,21 +521,24 @@ async fn adjust_block_receipts<Eth: EthWrapper>(
 async fn block_receipts_with_system_txs<Eth: EthWrapper>(
     block_id: BlockId,
     eth_api: &Eth,
-) -> Result<Option<Vec<RpcReceipt<Eth::NetworkTypes>>>, Eth::Error> {
+) -> Result<Option<BlockReceiptsWithSystemTx<RpcReceipt<Eth::NetworkTypes>>>, Eth::Error> {
+    let system_tx_count = system_tx_count_for_block(eth_api, block_id);
     if let Some((block, receipts)) = EthBlocks::load_block_and_receipts(eth_api, block_id).await? {
         let block_number = block.number;
         let base_fee = block.base_fee_per_gas;
         let block_hash = block.hash();
         let excess_blob_gas = block.excess_blob_gas;
         let timestamp = block.timestamp;
-        let mut gas_used = 0;
-        let mut next_log_index = 0;
+        let mut regular_gas_used = 0;
+        let mut regular_next_log_index = 0;
+        let mut system_gas_used = 0;
+        let mut system_next_log_index = 0;
 
-        let inputs = block
-            .transactions_recovered()
-            .zip(receipts.iter())
-            .enumerate()
-            .map(|(idx, (tx, receipt))| {
+        let mut regular_inputs = Vec::new();
+        let mut system_inputs = Vec::new();
+        for (idx, (tx, receipt)) in block.transactions_recovered().zip(receipts.iter()).enumerate()
+        {
+            if idx < system_tx_count {
                 let meta = TransactionMeta {
                     tx_hash: *tx.tx_hash(),
                     index: idx as u64,
@@ -538,19 +552,43 @@ async fn block_receipts_with_system_txs<Eth: EthWrapper>(
                 let input = ConvertReceiptInput {
                     receipt: receipt.clone(),
                     tx,
-                    gas_used: receipt.cumulative_gas_used() - gas_used,
-                    next_log_index,
+                    gas_used: receipt.cumulative_gas_used() - system_gas_used,
+                    next_log_index: system_next_log_index,
                     meta,
                 };
 
-                gas_used = receipt.cumulative_gas_used();
-                next_log_index += receipt.logs().len();
+                system_gas_used = receipt.cumulative_gas_used();
+                system_next_log_index += receipt.logs().len();
+                system_inputs.push(input);
+                continue;
+            }
 
-                input
-            })
-            .collect::<Vec<_>>();
+            let meta = TransactionMeta {
+                tx_hash: *tx.tx_hash(),
+                index: (idx - system_tx_count) as u64,
+                block_hash,
+                block_number,
+                base_fee,
+                excess_blob_gas,
+                timestamp,
+            };
 
-        return eth_api.tx_resp_builder().convert_receipts(inputs).map(Some);
+            let input = ConvertReceiptInput {
+                receipt: receipt.clone(),
+                tx,
+                gas_used: receipt.cumulative_gas_used() - regular_gas_used,
+                next_log_index: regular_next_log_index,
+                meta,
+            };
+
+            regular_gas_used = receipt.cumulative_gas_used();
+            regular_next_log_index += receipt.logs().len();
+            regular_inputs.push(input);
+        }
+
+        let receipts = eth_api.tx_resp_builder().convert_receipts(regular_inputs)?;
+        let system_tx_receipts = eth_api.tx_resp_builder().convert_receipts(system_inputs)?;
+        return Ok(Some(BlockReceiptsWithSystemTx { receipts, system_tx_receipts }));
     }
 
     Ok(None)
@@ -666,7 +704,7 @@ where
     async fn block_receipts_with_system_tx(
         &self,
         block_id: BlockId,
-    ) -> RpcResult<Option<Vec<RpcReceipt<Eth::NetworkTypes>>>> {
+    ) -> RpcResult<Option<BlockReceiptsWithSystemTx<RpcReceipt<Eth::NetworkTypes>>>> {
         trace!(target: "rpc::eth", ?block_id, "Serving eth_getBlockReceiptsWithSystemTx");
         if self.eth_api.provider().block_by_id(block_id).map_err(EthApiError::from)?.is_none() {
             return Ok(None);

--- a/src/node/spot_meta/init.rs
+++ b/src/node/spot_meta/init.rs
@@ -4,14 +4,8 @@ use crate::node::{
     types::reth_compat,
 };
 use alloy_primitives::Address;
-use reth_db::{
-    DatabaseEnv,
-    cursor::DbCursorRO,
-};
-use reth_db_api::{
-    Database,
-    transaction::DbTx,
-};
+use reth_db::{DatabaseEnv, cursor::DbCursorRO};
+use reth_db_api::{Database, transaction::DbTx};
 use std::{collections::BTreeMap, sync::Arc};
 use tracing::info;
 


### PR DESCRIPTION
Add `eth_getBlockReceiptsWithSystemTx` for `hl-node-compliant` mode.

This new endpoint returns both `receipts` (regular tx receipts with compliant indices/log indices) and `systemTxReceipts`, so clients can access full block receipts without changing `eth_getBlockReceipts` behavior.

```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "receipts": [
      {
        "type": "0x2",
        "status": "0x0",
        "cumulativeGasUsed": "0x6598b",
        "logs": [],
        "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
        "transactionHash": "0x1fbeddbf4803cdec4d8d6b8170be72c84e4fd9c56b46a8dd4e29ecfc1e0a016a",
        "transactionIndex": "0x0",
        "blockHash": "0x274d613818ef8494939b2a8ff0a2a1b040fbf22ecfa29b944fbf9fc1553e7387",
        "blockNumber": "0x16936d1",
        "gasUsed": "0x6598b",
        "effectiveGasPrice": "0x13b10d6e",
        "from": "0xc339d53ff876c506046fa2964062c6a35a458d72",
        "to": "0xb846367eddc6fa6f23c1e5ab550e75d1684f52fe",
        "contractAddress": null
      }
    ],
    "systemTxReceipts": [
      {
        "type": "0x0",
        "status": "0x1",
        "cumulativeGasUsed": "0x0",
        "logs": [
          {
            "address": "0xb88339cb7199b77e23db6e890353e22632ba630f",
            "topics": [
              "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
              "0x0000000000000000000000006b9e773128f453f5c2c60935ee2de2cbc5390a24",
              "0x000000000000000000000000f445eb1c08ca4c300994450a120994062b0a1a84"
            ],
            "data": "0x00000000000000000000000000000000000000000000000000000000017d7840",
            "blockHash": "0x274d613818ef8494939b2a8ff0a2a1b040fbf22ecfa29b944fbf9fc1553e7387",
            "blockNumber": "0x16936d1",
            "blockTimestamp": "0x695a7e2d",
            "transactionHash": "0xd2565352550c83debdc69955bc964386ef6af3918ee924119fe30fbec9b27fe3",
            "transactionIndex": "0x0",
            "logIndex": "0x0",
            "removed": false
          },
          {
            "address": "0x6b9e773128f453f5c2c60935ee2de2cbc5390a24",
            "topics": [
              "0x884edad9ce6fa2440d8a54cc123490eb96d2768479d49ff9c7366125a9424364",
              "0x000000000000000000000000f445eb1c08ca4c300994450a120994062b0a1a84"
            ],
            "data": "0x00000000000000000000000000000000000000000000000000000000017d7840",
            "blockHash": "0x274d613818ef8494939b2a8ff0a2a1b040fbf22ecfa29b944fbf9fc1553e7387",
            "blockNumber": "0x16936d1",
            "blockTimestamp": "0x695a7e2d",
            "transactionHash": "0xd2565352550c83debdc69955bc964386ef6af3918ee924119fe30fbec9b27fe3",
            "transactionIndex": "0x0",
            "logIndex": "0x1",
            "removed": false
          }
        ],
        "logsBloom": "0x00000000000000000000000000000000000000000000000000100000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000028000000000000000000000000100000000000000000000000000000000000000000000000000000000000000080000010000004001000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000002000000000020000000000000010000000000000000000000000000200000000000001000400000000000000000000000000000000000000000000020",
        "transactionHash": "0xd2565352550c83debdc69955bc964386ef6af3918ee924119fe30fbec9b27fe3",
        "transactionIndex": "0x0",
        "blockHash": "0x274d613818ef8494939b2a8ff0a2a1b040fbf22ecfa29b944fbf9fc1553e7387",
        "blockNumber": "0x16936d1",
        "gasUsed": "0x0",
        "effectiveGasPrice": "0x0",
        "from": "0x2000000000000000000000000000000000000000",
        "to": "0x6b9e773128f453f5c2c60935ee2de2cbc5390a24",
        "contractAddress": null
      }
    ]
  }
}
```