### PR TITLE
Add RPC-based node-to-node block syncing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+**/*.md
+!README.md

--- a/README.md
+++ b/README.md
@@ -58,6 +58,38 @@ $ reth-hl node --http --http.addr 0.0.0.0 --http.api eth,ots,net,web3 \
     --ws --ws.addr 0.0.0.0 --ws.origins '*' --ws.api eth,ots,net,web3 --ingest-dir ~/evm-blocks --local-ingest-dir <path-to-your-hl-node-evm-blocks-dir> --ws.port 8545
 ```
 
+## How to run (syncing from another nanoreth node via RPC)
+
+If you already have a nanoreth node running (e.g. in the cloud with S3 access), you can sync a local node from it without needing S3 credentials.
+
+**On the serving node** (cloud), add `--enable-sync-server` to its launch flags:
+
+```sh
+reth-hl node --http --http.addr 0.0.0.0 --http.api eth,ots,net,web3 \
+  --ws --ws.addr 0.0.0.0 --ws.origins '*' --ws.api eth,ots,net,web3 \
+  --ws.port 8545 --http.port 8545 --s3 --enable-sync-server
+```
+
+**On the local node**, point `--block-source` to the serving node's RPC:
+
+```sh
+reth-hl node --http --http.api eth,ots,net,web3 \
+  --block-source=rpc://your-cloud-node:8545
+```
+
+The `--rpc.polling-interval` flag controls how often the local node polls for new blocks (default: 100ms).
+
+## Architecture: How nanoreth differs from reth
+
+Nanoreth replaces reth's native P2P sync pipeline with a **pseudo peer + block source** architecture:
+
+- **Standard reth** syncs by downloading headers and bodies from P2P peers, then executing them through a staged pipeline (headers stage → bodies stage → execution stage).
+- **Nanoreth** fetches complete blocks (with receipts) from an external **block source** (S3, local files, or another nanoreth node via RPC). A "pseudo peer" process connects to the main node as a localhost P2P peer and serves these blocks when requested. Blocks are imported via the engine API (`new_payload` + `fork_choice_updated`), bypassing reth's download pipeline entirely.
+
+This means reth's `--bootnodes` and `--trusted-peers` flags will establish P2P connections but **will not trigger block sync** — the sync pipeline stages that request blocks from peers are not active in nanoreth. A block source (`--s3`, `--local`, `--block-source`) is required for syncing.
+
+Nanoreth also extends reth's block types with Hyperliquid-specific fields (`system_tx_count`, `read_precompile_calls`, `highest_precompile_address`, blob `sidecars`) that are not part of the standard Ethereum wire protocol, further requiring the custom sync path.
+
 ## How to run (testnet)
 
 Testnet is supported since block 34112653.

--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ The `--rpc.polling-interval` flag controls how often the local node polls for ne
 
 Nanoreth replaces reth's native P2P sync pipeline with a **pseudo peer + block source** architecture:
 
-- **Standard reth** syncs by downloading headers and bodies from P2P peers, then executing them through a staged pipeline (headers stage → bodies stage → execution stage).
-- **Nanoreth** fetches complete blocks (with receipts) from an external **block source** (S3, local files, or another nanoreth node via RPC). A "pseudo peer" process connects to the main node as a localhost P2P peer and serves these blocks when requested. Blocks are imported via the engine API (`new_payload` + `fork_choice_updated`), bypassing reth's download pipeline entirely.
+- **Standard reth** syncs by downloading headers and bodies from P2P peers, then re-executing every transaction locally to produce receipts and state. The eth wire protocol only transfers headers and bodies — receipts are never sent over P2P because each node generates its own.
+- **Nanoreth** does not re-execute blocks. Blocks arrive pre-executed from hl-node (the Go Hyperliquid node), so receipts must be **transferred** alongside blocks. Since the eth wire protocol has no mechanism for this, nanoreth fetches complete blocks (with receipts) from an external **block source** (S3, local files, or another nanoreth node via RPC). A "pseudo peer" process connects to the main node as a localhost P2P peer and serves these blocks when requested. Blocks are imported via the engine API (`new_payload` + `fork_choice_updated`), bypassing reth's download pipeline entirely.
 
-This means reth's `--bootnodes` and `--trusted-peers` flags will establish P2P connections but **will not trigger block sync** — the sync pipeline stages that request blocks from peers are not active in nanoreth. A block source (`--s3`, `--local`, `--block-source`) is required for syncing.
+This means reth's `--bootnodes` and `--trusted-peers` flags will establish P2P connections but **will not trigger historical block sync** — the sync pipeline stages that request blocks from peers are not active in nanoreth. A block source (`--s3`, `--local`, `--block-source`) is required for syncing.
 
 Nanoreth also extends reth's block types with Hyperliquid-specific fields (`system_tx_count`, `read_precompile_calls`, `highest_precompile_address`, blob `sidecars`) that are not part of the standard Ethereum wire protocol, further requiring the custom sync path.
 

--- a/src/addons/mod.rs
+++ b/src/addons/mod.rs
@@ -1,5 +1,6 @@
 pub mod call_forwarder;
 pub mod hl_node_compliance;
 pub mod subscribe_fixup;
+pub mod sync_server;
 pub mod tx_forwarder;
 mod utils;

--- a/src/addons/sync_server.rs
+++ b/src/addons/sync_server.rs
@@ -1,29 +1,72 @@
-use crate::pseudo_peer::sources::BlockSourceBoxed;
+use crate::node::types::BlockAndReceipts;
 use alloy_primitives::Bytes;
-use futures::StreamExt;
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee_core::{RpcResult, async_trait};
 use reth::rpc::result::internal_rpc_err;
 use std::sync::OnceLock;
 use tracing::trace;
 
-static BLOCK_SOURCE: OnceLock<BlockSourceBoxed> = OnceLock::new();
-
-/// Set the block source for the sync server.
-/// Called during node startup after the block source is created.
-pub fn set_sync_block_source(source: BlockSourceBoxed) {
-    BLOCK_SOURCE.set(source).ok();
+/// Trait for reading blocks from the database for the sync server.
+pub trait SyncBlockReader: Send + Sync + 'static {
+    fn read_block_and_receipts(&self, number: u64) -> eyre::Result<BlockAndReceipts>;
+    fn best_block_number(&self) -> eyre::Result<u64>;
 }
 
-fn get_sync_block_source() -> RpcResult<&'static BlockSourceBoxed> {
-    BLOCK_SOURCE
+/// Wraps any reth provider that implements the needed traits.
+pub struct ProviderSyncReader<P> {
+    provider: P,
+}
+
+impl<P> ProviderSyncReader<P> {
+    pub fn new(provider: P) -> Self {
+        Self { provider }
+    }
+}
+
+impl<P> SyncBlockReader for ProviderSyncReader<P>
+where
+    P: reth_provider::BlockReader<Block = crate::HlBlock>
+        + reth_provider::ReceiptProvider<Receipt = reth_ethereum_primitives::EthereumReceipt>
+        + reth_provider::BlockNumReader
+        + Send
+        + Sync
+        + 'static,
+{
+    fn read_block_and_receipts(&self, number: u64) -> eyre::Result<BlockAndReceipts> {
+        let block = self
+            .provider
+            .block_by_number(number)?
+            .ok_or_else(|| eyre::eyre!("Block {number} not found in database"))?;
+        let receipts = self
+            .provider
+            .receipts_by_block(number.into())?
+            .ok_or_else(|| eyre::eyre!("Receipts for block {number} not found in database"))?;
+        Ok(BlockAndReceipts::from_db(block, receipts))
+    }
+
+    fn best_block_number(&self) -> eyre::Result<u64> {
+        Ok(self.provider.last_block_number()?)
+    }
+}
+
+static DB_READER: OnceLock<Box<dyn SyncBlockReader>> = OnceLock::new();
+
+/// Set the database reader for the sync server.
+/// Called during node startup when `--enable-sync-server` is set.
+pub fn set_sync_db_reader(reader: Box<dyn SyncBlockReader>) {
+    DB_READER.set(reader).ok();
+}
+
+fn get_sync_db_reader() -> RpcResult<&'static dyn SyncBlockReader> {
+    DB_READER
         .get()
+        .map(|b| b.as_ref())
         .ok_or_else(|| internal_rpc_err("Sync server not yet initialized"))
 }
 
 /// RPC trait for node-to-node block syncing.
 ///
-/// Exposes blocks from this node's block source so other nanoreth nodes
+/// Serves blocks directly from the database so other nanoreth nodes
 /// can sync without needing direct S3 access.
 #[rpc(server, namespace = "hl")]
 #[async_trait]
@@ -33,11 +76,11 @@ pub trait HlSyncApi {
     async fn sync_get_block(&self, height: u64) -> RpcResult<Bytes>;
 
     /// Returns multiple blocks by height, serialized as msgpack+lz4 bytes.
-    /// Heights are capped at 100 per request.
+    /// Heights are capped at 500 per request.
     #[method(name = "syncGetBlocks")]
     async fn sync_get_blocks(&self, heights: Vec<u64>) -> RpcResult<Bytes>;
 
-    /// Returns the latest block number available from this node's block source.
+    /// Returns the latest block number available from this node's database.
     #[method(name = "syncLatestBlockNumber")]
     async fn sync_latest_block_number(&self) -> RpcResult<Option<u64>>;
 }
@@ -48,41 +91,33 @@ pub struct HlSyncServer;
 impl HlSyncApiServer for HlSyncServer {
     async fn sync_get_block(&self, height: u64) -> RpcResult<Bytes> {
         trace!(target: "rpc::hl", height, "Serving hl_syncGetBlock");
-        let source = get_sync_block_source()?;
-        let block = source
-            .collect_block(height)
-            .await
-            .map_err(|e| internal_rpc_err(format!("Failed to collect block {height}: {e}")))?;
+        let reader = get_sync_db_reader()?;
+        let block = reader
+            .read_block_and_receipts(height)
+            .map_err(|e| internal_rpc_err(format!("Failed to read block {height}: {e}")))?;
 
-        // Encode as msgpack + lz4 (same format as S3/local block sources)
+        // Encode as msgpack + lz4 (same format as S3/local block sources).
         // Use write_named (map format) to match the S3/Go msgpack format.
-        // The default write() uses compact/array format which causes
-        // deserialization errors due to field ordering differences.
         let mut encoder = lz4_flex::frame::FrameEncoder::new(Vec::new());
         rmp_serde::encode::write_named(&mut encoder, &vec![block])
             .map_err(|e| internal_rpc_err(format!("Failed to serialize block: {e}")))?;
         let compressed = encoder
             .finish()
             .map_err(|e| internal_rpc_err(format!("Failed to compress block: {e}")))?;
-
         Ok(Bytes::from(compressed))
     }
 
     async fn sync_get_blocks(&self, heights: Vec<u64>) -> RpcResult<Bytes> {
         const MAX_BATCH: usize = 500;
-        const CONCURRENCY: usize = 500;
         let heights = if heights.len() > MAX_BATCH { &heights[..MAX_BATCH] } else { &heights };
         trace!(target: "rpc::hl", count = heights.len(), "Serving hl_syncGetBlocks");
-        let source = get_sync_block_source()?;
+        let reader = get_sync_db_reader()?;
 
-        let futs: Vec<_> = heights.iter().map(|&h| source.collect_block(h)).collect();
-        let blocks: Vec<_> = futures::stream::iter(futs)
-            .buffered(CONCURRENCY)
-            .collect::<Vec<_>>()
-            .await
-            .into_iter()
+        let blocks: Vec<BlockAndReceipts> = heights
+            .iter()
+            .map(|&h| reader.read_block_and_receipts(h))
             .collect::<Result<_, _>>()
-            .map_err(|e| internal_rpc_err(format!("Failed to collect blocks: {e}")))?;
+            .map_err(|e| internal_rpc_err(format!("Failed to read blocks: {e}")))?;
 
         let mut encoder = lz4_flex::frame::FrameEncoder::new(Vec::new());
         rmp_serde::encode::write_named(&mut encoder, &blocks)
@@ -95,7 +130,11 @@ impl HlSyncApiServer for HlSyncServer {
 
     async fn sync_latest_block_number(&self) -> RpcResult<Option<u64>> {
         trace!(target: "rpc::hl", "Serving hl_syncLatestBlockNumber");
-        let source = get_sync_block_source()?;
-        Ok(source.find_latest_block_number().await)
+        let reader = get_sync_db_reader()?;
+        Ok(Some(
+            reader
+                .best_block_number()
+                .map_err(|e| internal_rpc_err(format!("Failed to get latest block: {e}")))?,
+        ))
     }
 }

--- a/src/addons/sync_server.rs
+++ b/src/addons/sync_server.rs
@@ -1,0 +1,67 @@
+use crate::pseudo_peer::sources::BlockSourceBoxed;
+use alloy_primitives::Bytes;
+use jsonrpsee::proc_macros::rpc;
+use jsonrpsee_core::{RpcResult, async_trait};
+use reth::rpc::result::internal_rpc_err;
+use std::sync::OnceLock;
+use tracing::trace;
+
+static BLOCK_SOURCE: OnceLock<BlockSourceBoxed> = OnceLock::new();
+
+/// Set the block source for the sync server.
+/// Called during node startup after the block source is created.
+pub fn set_sync_block_source(source: BlockSourceBoxed) {
+    BLOCK_SOURCE.set(source).ok();
+}
+
+fn get_sync_block_source() -> RpcResult<&'static BlockSourceBoxed> {
+    BLOCK_SOURCE
+        .get()
+        .ok_or_else(|| internal_rpc_err("Sync server not yet initialized"))
+}
+
+/// RPC trait for node-to-node block syncing.
+///
+/// Exposes blocks from this node's block source so other nanoreth nodes
+/// can sync without needing direct S3 access.
+#[rpc(server, namespace = "hl")]
+#[async_trait]
+pub trait HlSyncApi {
+    /// Returns a block at the given height, serialized as msgpack+lz4 bytes.
+    #[method(name = "syncGetBlock")]
+    async fn sync_get_block(&self, height: u64) -> RpcResult<Bytes>;
+
+    /// Returns the latest block number available from this node's block source.
+    #[method(name = "syncLatestBlockNumber")]
+    async fn sync_latest_block_number(&self) -> RpcResult<Option<u64>>;
+}
+
+pub struct HlSyncServer;
+
+#[async_trait]
+impl HlSyncApiServer for HlSyncServer {
+    async fn sync_get_block(&self, height: u64) -> RpcResult<Bytes> {
+        trace!(target: "rpc::hl", height, "Serving hl_syncGetBlock");
+        let source = get_sync_block_source()?;
+        let block = source
+            .collect_block(height)
+            .await
+            .map_err(|e| internal_rpc_err(format!("Failed to collect block {height}: {e}")))?;
+
+        // Encode as msgpack + lz4 (same format as S3/local block sources)
+        let mut encoder = lz4_flex::frame::FrameEncoder::new(Vec::new());
+        rmp_serde::encode::write(&mut encoder, &vec![block])
+            .map_err(|e| internal_rpc_err(format!("Failed to serialize block: {e}")))?;
+        let compressed = encoder
+            .finish()
+            .map_err(|e| internal_rpc_err(format!("Failed to compress block: {e}")))?;
+
+        Ok(Bytes::from(compressed))
+    }
+
+    async fn sync_latest_block_number(&self) -> RpcResult<Option<u64>> {
+        trace!(target: "rpc::hl", "Serving hl_syncLatestBlockNumber");
+        let source = get_sync_block_source()?;
+        Ok(source.find_latest_block_number().await)
+    }
+}

--- a/src/addons/sync_server.rs
+++ b/src/addons/sync_server.rs
@@ -69,7 +69,7 @@ impl HlSyncApiServer for HlSyncServer {
     }
 
     async fn sync_get_blocks(&self, heights: Vec<u64>) -> RpcResult<Bytes> {
-        const MAX_BATCH: usize = 100;
+        const MAX_BATCH: usize = 200;
         let heights = if heights.len() > MAX_BATCH { &heights[..MAX_BATCH] } else { &heights };
         trace!(target: "rpc::hl", count = heights.len(), "Serving hl_syncGetBlocks");
         let source = get_sync_block_source()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use reth_hl::{
         call_forwarder::{self, CallForwarderApiServer},
         hl_node_compliance::install_hl_node_compliance,
         subscribe_fixup::SubscribeFixup,
-        sync_server::{HlSyncApiServer, HlSyncServer},
+        sync_server::{HlSyncApiServer, HlSyncServer, ProviderSyncReader, set_sync_db_reader},
         tx_forwarder::{self, EthForwarderApiServer},
     },
     chainspec::{HlChainSpec, parser::HlChainSpecParser},
@@ -92,8 +92,10 @@ fn main() -> eyre::Result<()> {
                     }
 
                     if enable_sync_server {
+                        let provider = ctx.registry.eth_api().provider().clone();
+                        set_sync_db_reader(Box::new(ProviderSyncReader::new(provider)));
                         ctx.modules.merge_configured(HlSyncServer.into_rpc())?;
-                        info!("Sync server RPC enabled (hl_syncGetBlock, hl_syncLatestBlockNumber)");
+                        info!("Sync server RPC enabled (serving blocks from database)");
                     }
 
                     ctx.modules.merge_configured(

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use reth_hl::{
         call_forwarder::{self, CallForwarderApiServer},
         hl_node_compliance::install_hl_node_compliance,
         subscribe_fixup::SubscribeFixup,
+        sync_server::{HlSyncApiServer, HlSyncServer},
         tx_forwarder::{self, EthForwarderApiServer},
     },
     chainspec::{HlChainSpec, parser::HlChainSpecParser},
@@ -41,6 +42,7 @@ fn main() -> eyre::Result<()> {
          ext: HlNodeArgs| async move {
             let default_upstream_rpc_url = builder.config().chain.official_rpc_url();
 
+            let enable_sync_server = ext.enable_sync_server;
             let (node, engine_handle_tx) = HlNode::new(
                 ext.block_source_args.parse().await?,
                 ext.debug_cutoff_height,
@@ -87,6 +89,11 @@ fn main() -> eyre::Result<()> {
                     if !ext.experimental_eth_get_proof {
                         ctx.modules.remove_method_from_configured("eth_getProof");
                         info!("eth_getProof is disabled by default");
+                    }
+
+                    if enable_sync_server {
+                        ctx.modules.merge_configured(HlSyncServer.into_rpc())?;
+                        info!("Sync server RPC enabled (hl_syncGetBlock, hl_syncLatestBlockNumber)");
                     }
 
                     ctx.modules.merge_configured(

--- a/src/node/cli.rs
+++ b/src/node/cli.rs
@@ -89,6 +89,13 @@ pub struct HlNodeArgs {
     /// will be taken from CLI arguments instead of being hardcoded to localhost-only defaults.
     #[arg(long, env = "ALLOW_NETWORK_OVERRIDES")]
     pub allow_network_overrides: bool,
+
+    /// Enable the sync server RPC endpoints (hl_syncGetBlock, hl_syncLatestBlockNumber).
+    ///
+    /// When enabled, this node can serve blocks to other nanoreth nodes
+    /// that use --block-source=rpc://... to sync from this node.
+    #[arg(long, env = "ENABLE_SYNC_SERVER")]
+    pub enable_sync_server: bool,
 }
 
 /// The main reth_hl cli interface.

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -49,14 +49,14 @@ pub type HlNodeAddOns<N> =
 #[derive(Debug, Clone)]
 pub struct HlNode {
     engine_handle_rx: Arc<Mutex<Option<oneshot::Receiver<ConsensusEngineHandle<HlPayloadTypes>>>>>,
-    block_source_config: BlockSourceConfig,
+    block_source_config: Option<BlockSourceConfig>,
     debug_cutoff_height: Option<u64>,
     allow_network_overrides: bool,
 }
 
 impl HlNode {
     pub fn new(
-        block_source_config: BlockSourceConfig,
+        block_source_config: Option<BlockSourceConfig>,
         debug_cutoff_height: Option<u64>,
         allow_network_overrides: bool,
     ) -> (Self, oneshot::Sender<ConsensusEngineHandle<HlPayloadTypes>>) {

--- a/src/node/network/mod.rs
+++ b/src/node/network/mod.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::owned_cow)]
 use crate::{
     HlBlock,
+    addons::sync_server::set_sync_block_source,
     consensus::HlConsensus,
     node::{
         HlNode,
@@ -144,7 +145,8 @@ pub struct HlNetworkBuilder {
     pub(crate) engine_handle_rx:
         Arc<Mutex<Option<oneshot::Receiver<ConsensusEngineHandle<HlPayloadTypes>>>>>,
 
-    pub(crate) block_source_config: BlockSourceConfig,
+    // optional because we might sync from network
+    pub(crate) block_source_config: Option<BlockSourceConfig>,
 
     pub(crate) debug_cutoff_height: Option<u64>,
 
@@ -225,26 +227,32 @@ where
         let local_node_record = handle.local_node_record();
         info!(target: "reth::cli", enode=%local_node_record, "P2P networking initialized");
 
-        let next_block_number = ctx
-            .provider()
-            .get_stage_checkpoint(StageId::Finish)?
-            .unwrap_or_default()
-            .block_number +
-            1;
+        if let Some(block_source_config) = block_source_config {
+            let next_block_number = ctx
+                .provider()
+                .get_stage_checkpoint(StageId::Finish)?
+                .unwrap_or_default()
+                .block_number
+                + 1;
 
-        let chain_spec = ctx.chain_spec();
-        ctx.task_executor().spawn_critical("pseudo peer", async move {
-            start_pseudo_peer(
-                chain_spec.clone(),
-                local_node_record.to_string(),
-                block_source_config
+            let chain_spec = ctx.chain_spec();
+            ctx.task_executor().spawn_critical("pseudo peer", async move {
+                let block_source = block_source_config
                     .create_cached_block_source((*chain_spec).clone(), next_block_number)
-                    .await,
-                debug_cutoff_height,
-            )
-            .await
-            .unwrap();
-        });
+                    .await;
+                set_sync_block_source(block_source.clone());
+                start_pseudo_peer(
+                    chain_spec.clone(),
+                    local_node_record.to_string(),
+                    block_source,
+                    debug_cutoff_height,
+                )
+                .await
+                .unwrap();
+            });
+        } else {
+            info!(target: "reth::cli", "No block source configured - syncing from P2P peers only");
+        }
 
         Ok(handle)
     }

--- a/src/node/network/mod.rs
+++ b/src/node/network/mod.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::owned_cow)]
 use crate::{
     HlBlock,
-    addons::sync_server::set_sync_block_source,
     consensus::HlConsensus,
     node::{
         HlNode,
@@ -240,7 +239,6 @@ where
                 let block_source = block_source_config
                     .create_cached_block_source((*chain_spec).clone(), next_block_number)
                     .await;
-                set_sync_block_source(block_source.clone());
                 start_pseudo_peer(
                     chain_spec.clone(),
                     local_node_record.to_string(),

--- a/src/node/types/reth_compat.rs
+++ b/src/node/types/reth_compat.rs
@@ -47,6 +47,48 @@ pub struct TransactionSigned {
     transaction: Transaction,
 }
 impl TransactionSigned {
+    /// Convert from the node's TransactionSigned back to reth_compat format.
+    pub fn from_node_tx(tx: TxSigned) -> Self {
+        use alloy_consensus::EthereumTxEnvelope;
+        let inner = tx.into_inner();
+        match inner {
+            EthereumTxEnvelope::Legacy(signed) => {
+                let (tx, sig, _) = signed.into_parts();
+                Self { signature: sig, transaction: Transaction::Legacy(tx) }
+            }
+            EthereumTxEnvelope::Eip2930(signed) => {
+                let (tx, sig, _) = signed.into_parts();
+                Self { signature: sig, transaction: Transaction::Eip2930(tx) }
+            }
+            EthereumTxEnvelope::Eip1559(signed) => {
+                let (tx, sig, _) = signed.into_parts();
+                Self { signature: sig, transaction: Transaction::Eip1559(tx) }
+            }
+            EthereumTxEnvelope::Eip4844(signed) => {
+                let (tx, sig, _) = signed.into_parts();
+                Self { signature: sig, transaction: Transaction::Eip4844(tx) }
+            }
+            EthereumTxEnvelope::Eip7702(signed) => {
+                let (tx, sig, _) = signed.into_parts();
+                Self { signature: sig, transaction: Transaction::Eip7702(tx) }
+            }
+        }
+    }
+
+    /// Extract just the transaction (without signature) from a node TransactionSigned.
+    /// Used for system transactions where the signature is fabricated.
+    pub fn extract_transaction(tx: TxSigned) -> Transaction {
+        use alloy_consensus::EthereumTxEnvelope;
+        let inner = tx.into_inner();
+        match inner {
+            EthereumTxEnvelope::Legacy(signed) => Transaction::Legacy(signed.into_parts().0),
+            EthereumTxEnvelope::Eip2930(signed) => Transaction::Eip2930(signed.into_parts().0),
+            EthereumTxEnvelope::Eip1559(signed) => Transaction::Eip1559(signed.into_parts().0),
+            EthereumTxEnvelope::Eip4844(signed) => Transaction::Eip4844(signed.into_parts().0),
+            EthereumTxEnvelope::Eip7702(signed) => Transaction::Eip7702(signed.into_parts().0),
+        }
+    }
+
     fn to_reth_transaction(&self) -> TxSigned {
         match self.transaction.clone() {
             Transaction::Legacy(tx) => {

--- a/src/pseudo_peer/mod.rs
+++ b/src/pseudo_peer/mod.rs
@@ -25,7 +25,7 @@ pub mod prelude {
     pub use super::{
         config::BlockSourceConfig,
         service::{BlockPoller, PseudoPeer},
-        sources::{BlockSource, CachedBlockSource, LocalBlockSource, S3BlockSource},
+        sources::{BlockSource, CachedBlockSource, LocalBlockSource, RpcBlockSource, S3BlockSource},
     };
 }
 

--- a/src/pseudo_peer/sources/cached.rs
+++ b/src/pseudo_peer/sources/cached.rs
@@ -2,7 +2,7 @@ use super::{BlockSource, BlockSourceBoxed};
 use crate::node::types::BlockAndReceipts;
 use futures::{FutureExt, future::BoxFuture};
 use reth_network::cache::LruMap;
-use std::sync::{Arc, RwLock};
+use std::{collections::HashMap, sync::{Arc, RwLock}};
 
 /// Block source wrapper that caches blocks in memory
 #[derive(Debug, Clone)]
@@ -40,6 +40,51 @@ impl BlockSource for CachedBlockSource {
 
     fn recommended_chunk_size(&self) -> u64 {
         self.block_source.recommended_chunk_size()
+    }
+
+    fn collect_blocks(
+        &self,
+        heights: Vec<u64>,
+    ) -> BoxFuture<'static, eyre::Result<Vec<BlockAndReceipts>>> {
+        let block_source = self.block_source.clone();
+        let cache = self.cache.clone();
+        async move {
+            // Split into cached and uncached
+            let mut cached: HashMap<u64, BlockAndReceipts> = HashMap::new();
+            let mut uncached_heights = Vec::new();
+            {
+                let mut c = cache.write().unwrap();
+                for &h in &heights {
+                    if let Some(block) = c.get(&h) {
+                        cached.insert(h, block.clone());
+                    } else {
+                        uncached_heights.push(h);
+                    }
+                }
+            }
+
+            // Batch fetch uncached blocks from inner source
+            if !uncached_heights.is_empty() {
+                let fetched = block_source.collect_blocks(uncached_heights).await?;
+                let mut c = cache.write().unwrap();
+                for block in fetched {
+                    let h = block.number();
+                    c.insert(h, block.clone());
+                    cached.insert(h, block);
+                }
+            }
+
+            // Return in original order
+            heights
+                .iter()
+                .map(|h| {
+                    cached
+                        .remove(h)
+                        .ok_or_else(|| eyre::eyre!("Block {h} not found"))
+                })
+                .collect()
+        }
+        .boxed()
     }
 
     fn polling_interval(&self) -> std::time::Duration {

--- a/src/pseudo_peer/sources/mod.rs
+++ b/src/pseudo_peer/sources/mod.rs
@@ -7,6 +7,7 @@ use std::{sync::Arc, time::Duration};
 mod cached;
 mod hl_node;
 mod local;
+mod rpc;
 mod s3;
 mod utils;
 
@@ -14,6 +15,7 @@ mod utils;
 pub use cached::CachedBlockSource;
 pub use hl_node::{HlNodeBlockSource, HlNodeBlockSourceArgs};
 pub use local::LocalBlockSource;
+pub use rpc::RpcBlockSource;
 pub use s3::S3BlockSource;
 
 const DEFAULT_POLLING_INTERVAL: Duration = Duration::from_millis(25);

--- a/src/pseudo_peer/sources/rpc.rs
+++ b/src/pseudo_peer/sources/rpc.rs
@@ -31,7 +31,7 @@ pub struct RpcBlockSourceMetrics {
 impl RpcBlockSource {
     pub fn new(url: String, polling_interval: Duration) -> Self {
         let client = HttpClientBuilder::default()
-            .request_timeout(Duration::from_secs(30))
+            .request_timeout(Duration::from_secs(120))
             .build(&url)
             .unwrap_or_else(|e| panic!("Failed to build RPC client for {url}: {e}"));
         info!("RPC block source connected to {url}");
@@ -72,7 +72,7 @@ impl BlockSource for RpcBlockSource {
         let client = self.client.clone();
         let metrics = self.metrics.clone();
         async move {
-            const BATCH_SIZE: usize = 200;
+            const BATCH_SIZE: usize = 500;
             const MAX_CONCURRENT_BATCHES: usize = 20;
 
             let batches: Vec<Vec<u64>> =

--- a/src/pseudo_peer/sources/rpc.rs
+++ b/src/pseudo_peer/sources/rpc.rs
@@ -1,0 +1,75 @@
+use super::BlockSource;
+use crate::node::types::BlockAndReceipts;
+use alloy_primitives::Bytes;
+use futures::{FutureExt, future::BoxFuture};
+use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
+use jsonrpsee_core::client::ClientT;
+use reth_metrics::{Metrics, metrics, metrics::Counter};
+use std::{sync::Arc, time::Duration};
+use tracing::info;
+
+/// Block source that fetches blocks from a remote nanoreth node via RPC.
+///
+/// Connects to another nanoreth node running with `--enable-sync-server`
+/// and fetches blocks through the `hl_sync` RPC namespace.
+#[derive(Debug, Clone)]
+pub struct RpcBlockSource {
+    client: Arc<HttpClient>,
+    polling_interval: Duration,
+    metrics: RpcBlockSourceMetrics,
+}
+
+#[derive(Metrics, Clone)]
+#[metrics(scope = "block_source.rpc")]
+pub struct RpcBlockSourceMetrics {
+    /// How many times the RPC block source is polling for a block
+    pub polling_attempt: Counter,
+    /// How many times the RPC block source has fetched a block
+    pub fetched: Counter,
+}
+
+impl RpcBlockSource {
+    pub fn new(url: String, polling_interval: Duration) -> Self {
+        let client = HttpClientBuilder::default()
+            .request_timeout(Duration::from_secs(30))
+            .build(&url)
+            .unwrap_or_else(|e| panic!("Failed to build RPC client for {url}: {e}"));
+        info!("RPC block source connected to {url}");
+        Self { client: Arc::new(client), polling_interval, metrics: RpcBlockSourceMetrics::default() }
+    }
+}
+
+impl BlockSource for RpcBlockSource {
+    fn collect_block(&self, height: u64) -> BoxFuture<'static, eyre::Result<BlockAndReceipts>> {
+        let client = self.client.clone();
+        let metrics = self.metrics.clone();
+        async move {
+            metrics.polling_attempt.increment(1);
+            let bytes: Bytes = client.request("hl_syncGetBlock", (height,)).await?;
+            let mut decoder = lz4_flex::frame::FrameDecoder::new(&bytes[..]);
+            let blocks: Vec<BlockAndReceipts> = rmp_serde::from_read(&mut decoder)?;
+            metrics.fetched.increment(1);
+            Ok(blocks[0].clone())
+        }
+        .boxed()
+    }
+
+    fn find_latest_block_number(&self) -> BoxFuture<'static, Option<u64>> {
+        let client = self.client.clone();
+        async move {
+            let result: Option<u64> =
+                client.request("hl_syncLatestBlockNumber", Vec::<u64>::new()).await.ok()?;
+            info!("Latest block number from remote: {:?}", result);
+            result
+        }
+        .boxed()
+    }
+
+    fn recommended_chunk_size(&self) -> u64 {
+        100
+    }
+
+    fn polling_interval(&self) -> Duration {
+        self.polling_interval
+    }
+}

--- a/src/pseudo_peer/sources/rpc.rs
+++ b/src/pseudo_peer/sources/rpc.rs
@@ -66,7 +66,7 @@ impl BlockSource for RpcBlockSource {
     }
 
     fn recommended_chunk_size(&self) -> u64 {
-        100
+        1000
     }
 
     fn polling_interval(&self) -> Duration {

--- a/src/pseudo_peer/sources/rpc.rs
+++ b/src/pseudo_peer/sources/rpc.rs
@@ -66,7 +66,7 @@ impl BlockSource for RpcBlockSource {
     }
 
     fn recommended_chunk_size(&self) -> u64 {
-        1000
+        200
     }
 
     fn polling_interval(&self) -> Duration {

--- a/src/pseudo_peer/sources/rpc.rs
+++ b/src/pseudo_peer/sources/rpc.rs
@@ -72,8 +72,8 @@ impl BlockSource for RpcBlockSource {
         let client = self.client.clone();
         let metrics = self.metrics.clone();
         async move {
-            const BATCH_SIZE: usize = 100;
-            const MAX_CONCURRENT_BATCHES: usize = 10;
+            const BATCH_SIZE: usize = 200;
+            const MAX_CONCURRENT_BATCHES: usize = 20;
 
             let batches: Vec<Vec<u64>> =
                 heights.chunks(BATCH_SIZE).map(|c| c.to_vec()).collect();


### PR DESCRIPTION
- Add RPC sync server (--enable-sync-server) that serves blocks directly from the database to other nanoreth nodes
- Add RPC block source (--block-source=rpc://host:port) to sync from a remote nanoreth node
- Batch block fetching via hl_syncGetBlocks endpoint (500 blocks/batch, 20 concurrent batches) for high throughput
- Sync server reads from the local database instead of re-fetching from S3, making it significantly faster
- Reverse type conversions (HlBlock + receipts → BlockAndReceipts wire format) for DB-based serving
- README documents architecture differences explaining why native P2P sync doesn't work (no receipt transfer in eth wire protocol)