### PR TITLE
fix(compat): normalize legacy yParity values in S3 block deserialization

### DIFF
--- a/src/node/types/reth_compat.rs
+++ b/src/node/types/reth_compat.rs
@@ -1,7 +1,7 @@
 //! Copy of reth codebase to preserve serialization compatibility
 use crate::node::storage::tables::{SPOT_METADATA_KEY, SpotMetadata};
 use alloy_consensus::{Header, Signed, TxEip1559, TxEip2930, TxEip4844, TxEip7702, TxLegacy};
-use alloy_primitives::{Address, BlockHash, Bytes, Signature, TxKind, U256};
+use alloy_primitives::{Address, BlockHash, Bytes, Signature, TxKind, U256, U64, normalize_v};
 use reth_db::{DatabaseEnv, DatabaseError, cursor::DbCursorRW};
 use reth_db_api::{Database, transaction::DbTxMut};
 use reth_primitives::TransactionSigned as RethTxSigned;
@@ -33,6 +33,26 @@ pub enum Transaction {
     Eip7702(TxEip7702),
 }
 
+/// Custom deserializer for [`Signature`] that accepts legacy `v` values (27, 28, EIP-155 ≥35)
+/// in addition to the standard 0/1 parity. S3 testnet blocks encode the full `v` value in
+/// the msgpack tuple rather than the normalized boolean parity that alloy-primitives expects.
+fn deserialize_compat_signature<'de, D>(deserializer: D) -> Result<Signature, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    if deserializer.is_human_readable() {
+        // Human-readable path (JSON) — delegate to default which already handles v normalization
+        Signature::deserialize(deserializer)
+    } else {
+        // Non-human-readable path (msgpack) — deserialize raw tuple and normalize v
+        let (r, s, v_raw) = <(U256, U256, U64)>::deserialize(deserializer)?;
+        let v = v_raw.to::<u64>();
+        let y_parity = normalize_v(v)
+            .ok_or_else(|| serde::de::Error::custom(format!("invalid v value: {v}")))?;
+        Ok(Signature::new(r, s, y_parity))
+    }
+}
+
 /// Signed Ethereum transaction.
 #[derive(
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, derive_more::AsRef, derive_more::Deref,
@@ -40,6 +60,7 @@ pub enum Transaction {
 #[serde(rename_all = "camelCase")]
 pub struct TransactionSigned {
     /// The transaction signature values
+    #[serde(deserialize_with = "deserialize_compat_signature")]
     signature: Signature,
     /// Raw transaction info
     #[deref]
@@ -241,5 +262,132 @@ impl SealedBlock {
             ),
             body: block_body,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::TxLegacy;
+    use alloy_primitives::{Signature, TxKind, U256};
+
+    /// Helper: build a minimal TransactionSigned for testing.
+    fn make_tx(y_parity: bool) -> TransactionSigned {
+        TransactionSigned {
+            signature: Signature::new(U256::from(1), U256::from(2), y_parity),
+            transaction: Transaction::Legacy(TxLegacy {
+                chain_id: Some(998),
+                nonce: 0,
+                gas_price: 0,
+                gas_limit: 21000,
+                to: TxKind::Call(Address::ZERO),
+                value: U256::ZERO,
+                input: Bytes::new(),
+            }),
+        }
+    }
+
+    #[test]
+    fn test_msgpack_roundtrip_standard_parity() {
+        // Standard 0/1 parity should round-trip through msgpack without issue.
+        for parity in [false, true] {
+            let tx = make_tx(parity);
+            let encoded = rmp_serde::to_vec(&tx).expect("serialize");
+            let decoded: TransactionSigned =
+                rmp_serde::from_slice(&encoded).expect("deserialize");
+            assert_eq!(tx, decoded);
+        }
+    }
+
+    #[test]
+    fn test_msgpack_legacy_v_values() {
+        // Simulate S3 blocks that encode v=27 or v=28 instead of 0/1.
+        for (legacy_v, expected_parity) in [(27u64, false), (28u64, true)] {
+            let tx = make_tx(expected_parity);
+
+            // The Signature is serialized as a (U256, U256, U64) tuple in msgpack.
+            // U64 is 8 bytes big-endian. Standard encoding writes 0x00..00 or 0x00..01.
+            // We need to find and replace the last U64 in the signature tuple with legacy_v.
+            //
+            // Rather than fragile byte patching, let's construct the tuple directly:
+            // Serialize the signature portion manually and rebuild the full message.
+            let sig_tuple: (U256, U256, U64) =
+                (U256::from(1), U256::from(2), U64::from(legacy_v));
+            let sig_bytes = rmp_serde::to_vec(&sig_tuple).expect("serialize sig tuple");
+
+            // Now serialize just the transaction portion
+            let tx_bytes =
+                rmp_serde::to_vec(&tx.transaction).expect("serialize transaction");
+
+            // TransactionSigned is serialized as a 2-element array [signature, transaction]
+            // in msgpack non-human-readable format (serde tuple struct).
+            // Build it manually: fixarray(2) + sig_bytes + tx_bytes
+            let mut patched = Vec::new();
+            patched.push(0x92); // msgpack fixarray of 2 elements
+            patched.extend_from_slice(&sig_bytes);
+            patched.extend_from_slice(&tx_bytes);
+
+            let decoded: TransactionSigned =
+                rmp_serde::from_slice(&patched).expect(&format!(
+                    "deserialize with legacy v={legacy_v} should succeed"
+                ));
+            assert_eq!(decoded.signature.v(), expected_parity);
+        }
+    }
+
+    /// Integration test: deserialize real S3 block files from the local cache.
+    /// Run with: cargo test -- --ignored test_deserialize_real_blocks
+    #[test]
+    #[ignore]
+    fn test_deserialize_real_blocks() {
+        use crate::node::types::BlockAndReceipts;
+        use std::path::Path;
+
+        let blocks_dir = Path::new(
+            &std::env::var("BLOCKS_DIR").unwrap_or_else(|_| {
+                let home = std::env::var("HOME").expect("HOME not set");
+                format!("{home}/projects/hyperliquid/nfth-mm/data/blocks")
+            }),
+        )
+        .to_path_buf();
+
+        if !blocks_dir.exists() {
+            eprintln!("Skipping: blocks dir not found at {blocks_dir:?}");
+            return;
+        }
+
+        // Test blocks from the problematic 45.9M range — includes larger files
+        // that are more likely to contain user transactions with signatures.
+        let test_blocks = [45_900_126u64, 45_900_432, 45_900_512, 45_900_737];
+        let mut tested = 0;
+
+        for block_num in test_blocks {
+            let million = (block_num / 1_000_000) * 1_000_000;
+            let thousand = (block_num / 1_000) * 1_000;
+            let path = blocks_dir
+                .join(million.to_string())
+                .join(thousand.to_string())
+                .join(format!("{block_num}.rmp.lz4"));
+
+            if !path.exists() {
+                eprintln!("Skipping block {block_num}: file not found at {path:?}");
+                continue;
+            }
+
+            let file = std::fs::read(&path).unwrap();
+            let mut decoder = lz4_flex::frame::FrameDecoder::new(&file[..]);
+            let blocks: Vec<BlockAndReceipts> = rmp_serde::from_read(&mut decoder)
+                .unwrap_or_else(|e| panic!("Failed to deserialize block {block_num}: {e}"));
+
+            assert!(!blocks.is_empty(), "Block file {block_num} was empty");
+            let crate::node::types::EvmBlock::Reth115(ref sealed) = blocks[0].block;
+            eprintln!(
+                "OK: block {block_num} deserialized ({} txs)",
+                sealed.body.transactions.len()
+            );
+            tested += 1;
+        }
+
+        assert!(tested > 0, "No block files found to test — check BLOCKS_DIR");
     }
 }


### PR DESCRIPTION
## Summary

- S3 testnet blocks around block 45.9M encode legacy `v` values (27, 28, EIP-155 ≥35) in the msgpack signature tuple instead of the normalized boolean parity (0/1) that `alloy-primitives` expects
- This causes `invalid yParity` deserialization errors, which after ~13 failures triggers a peer disconnect and stalls the sync pipeline
- Adds a custom deserializer for `Signature` on the non-human-readable (msgpack) path that normalizes raw `v` values via `alloy_primitives::normalize_v`
- The human-readable (JSON) path delegates to the default `Signature::deserialize` which already handles normalization

## Test plan

- [x] Unit tests for standard 0/1 parity round-trip through msgpack
- [x] Unit tests for legacy v=27/v=28 values in msgpack deserialization
- [ ] Integration test against real S3 block files from the problematic 45.9M range (`cargo test -- --ignored test_deserialize_real_blocks`)
- [ ] Full sync test: verify Headers stage completes past the 45.9M block range without peer disconnection

🤖 Generated with [Claude Code](https://claude.com/claude-code)