### PR TITLE
refactor(pseudo-peer): direct trusted peer + DB hash resolution

### DIFF
--- a/src/node/cli.rs
+++ b/src/node/cli.rs
@@ -174,23 +174,23 @@ where
                 // Validate file paths early with clear error messages.
                 // On Linux, File::open() succeeds on directories, then read_to_end()
                 // fails with a cryptic "Is a directory" error.
-                if command.without_evm {
-                    if let Some(ref path) = command.header {
-                        if path.is_dir() {
-                            return Err(eyre::eyre!(
-                                "--header path '{}' is a directory, not a file. \
-                                 If using Docker, ensure the source file exists on the host \
-                                 (missing source files cause Docker to create directories \
-                                 at the mount point).",
-                                path.display()
-                            ));
-                        }
-                        if !path.exists() {
-                            return Err(eyre::eyre!(
-                                "--header path '{}' does not exist",
-                                path.display()
-                            ));
-                        }
+                if command.without_evm
+                    && let Some(ref path) = command.header
+                {
+                    if path.is_dir() {
+                        return Err(eyre::eyre!(
+                            "--header path '{}' is a directory, not a file. \
+                             If using Docker, ensure the source file exists on the host \
+                             (missing source files cause Docker to create directories \
+                             at the mount point).",
+                            path.display()
+                        ));
+                    }
+                    if !path.exists() {
+                        return Err(eyre::eyre!(
+                            "--header path '{}' does not exist",
+                            path.display()
+                        ));
                     }
                 }
                 if command.state.is_dir() {

--- a/src/node/network/mod.rs
+++ b/src/node/network/mod.rs
@@ -27,8 +27,8 @@ use reth_network::{NetworkConfig, NetworkHandle, NetworkManager};
 use reth_network_api::PeersInfo;
 use reth_payload_primitives::EngineApiMessageVersion;
 use reth_provider::StageCheckpointReader;
-use reth_storage_api::{BlockHashReader, BlockNumReader};
 use reth_stages_types::StageId;
+use reth_storage_api::{BlockHashReader, BlockNumReader};
 use std::{
     net::{Ipv4Addr, SocketAddr},
     sync::Arc,
@@ -267,8 +267,8 @@ where
                 .provider()
                 .get_stage_checkpoint(StageId::Finish)?
                 .unwrap_or_default()
-                .block_number
-                + 1;
+                .block_number +
+                1;
 
             let chain_spec = ctx.chain_spec();
             let chain_id = chain_spec.inner.chain().id();
@@ -284,8 +284,7 @@ where
                     match block_source.collect_block(latest).await {
                         Ok(block) => {
                             let reth_block = block.to_reth_block(chain_id);
-                            let hash =
-                                alloy_primitives::Sealable::hash_slow(&reth_block.header);
+                            let hash = alloy_primitives::Sealable::hash_slow(&reth_block.header);
                             info!(
                                 target: "reth::cli",
                                 number = %latest,

--- a/src/node/network/mod.rs
+++ b/src/node/network/mod.rs
@@ -9,7 +9,7 @@ use crate::{
         rpc::engine_api::payload::HlPayloadTypes,
         types::ReadPrecompileCalls,
     },
-    pseudo_peer::{BlockSourceConfig, start_pseudo_peer},
+    pseudo_peer::{BlockSourceConfig, DbBlockNumberFn, start_pseudo_peer},
 };
 use alloy_primitives::B256;
 use alloy_rlp::{Decodable, Encodable};
@@ -270,6 +270,13 @@ where
                 .block_number +
                 1;
 
+            // Give the pseudo-peer a handle to the node's database so it can
+            // resolve hash→number directly instead of scanning the block source.
+            let provider = ctx.provider().clone();
+            let db_block_number: DbBlockNumberFn = Arc::new(move |hash| {
+                provider.block_number(hash).ok().flatten()
+            });
+
             let chain_spec = ctx.chain_spec();
             let chain_id = chain_spec.inner.chain().id();
             ctx.task_executor().spawn_critical("pseudo peer", async move {
@@ -308,6 +315,7 @@ where
                     local_node_record.to_string(),
                     block_source,
                     debug_cutoff_height,
+                    Some(db_block_number),
                 )
                 .await
                 .unwrap();

--- a/src/node/types/mod.rs
+++ b/src/node/types/mod.rs
@@ -84,20 +84,34 @@ impl BlockAndReceipts {
         let all_txs = block.body.inner.transactions;
 
         // Split system txs from regular txs
-        let (system_tx_list, regular_tx_list) = if system_tx_count > 0 && system_tx_count <= all_txs.len() {
-            let (sys, reg) = all_txs.into_iter().enumerate().partition::<Vec<_>, _>(|(i, _)| *i < system_tx_count);
-            (sys.into_iter().map(|(_, tx)| tx).collect::<Vec<_>>(), reg.into_iter().map(|(_, tx)| tx).collect::<Vec<_>>())
-        } else {
-            (vec![], all_txs)
-        };
+        let (system_tx_list, regular_tx_list) =
+            if system_tx_count > 0 && system_tx_count <= all_txs.len() {
+                let (sys, reg) = all_txs
+                    .into_iter()
+                    .enumerate()
+                    .partition::<Vec<_>, _>(|(i, _)| *i < system_tx_count);
+                (
+                    sys.into_iter().map(|(_, tx)| tx).collect::<Vec<_>>(),
+                    reg.into_iter().map(|(_, tx)| tx).collect::<Vec<_>>(),
+                )
+            } else {
+                (vec![], all_txs)
+            };
 
         // Split receipts
-        let (system_receipts, regular_receipts) = if system_tx_count > 0 && system_tx_count <= receipts.len() {
-            let (sys, reg) = receipts.into_iter().enumerate().partition::<Vec<_>, _>(|(i, _)| *i < system_tx_count);
-            (sys.into_iter().map(|(_, r)| r).collect::<Vec<_>>(), reg.into_iter().map(|(_, r)| r).collect::<Vec<_>>())
-        } else {
-            (vec![], receipts)
-        };
+        let (system_receipts, regular_receipts) =
+            if system_tx_count > 0 && system_tx_count <= receipts.len() {
+                let (sys, reg) = receipts
+                    .into_iter()
+                    .enumerate()
+                    .partition::<Vec<_>, _>(|(i, _)| *i < system_tx_count);
+                (
+                    sys.into_iter().map(|(_, r)| r).collect::<Vec<_>>(),
+                    reg.into_iter().map(|(_, r)| r).collect::<Vec<_>>(),
+                )
+            } else {
+                (vec![], receipts)
+            };
 
         // Convert system transactions
         let system_txs: Vec<SystemTx> = system_tx_list
@@ -110,22 +124,15 @@ impl BlockAndReceipts {
             .collect();
 
         // Convert regular transactions to reth_compat format
-        let compat_txs: Vec<reth_compat::TransactionSigned> = regular_tx_list
-            .into_iter()
-            .map(reth_compat::TransactionSigned::from_node_tx)
-            .collect();
+        let compat_txs: Vec<reth_compat::TransactionSigned> =
+            regular_tx_list.into_iter().map(reth_compat::TransactionSigned::from_node_tx).collect();
 
         // Convert regular receipts
-        let legacy_receipts: Vec<LegacyReceipt> = regular_receipts
-            .into_iter()
-            .map(Into::into)
-            .collect();
+        let legacy_receipts: Vec<LegacyReceipt> =
+            regular_receipts.into_iter().map(Into::into).collect();
 
         let sealed_block = reth_compat::SealedBlock {
-            header: reth_compat::SealedHeader {
-                hash,
-                header: block.header.inner,
-            },
+            header: reth_compat::SealedHeader { hash, header: block.header.inner },
             body: alloy_consensus::BlockBody {
                 transactions: compat_txs,
                 ommers: vec![],

--- a/src/pseudo_peer/cli.rs
+++ b/src/pseudo_peer/cli.rs
@@ -85,10 +85,7 @@ impl BlockSourceArgs {
             } else {
                 format!("http://{url}")
             };
-            Ok(Some(BlockSourceConfig::rpc(
-                url,
-                Duration::from_millis(self.rpc_polling_interval),
-            )))
+            Ok(Some(BlockSourceConfig::rpc(url, Duration::from_millis(self.rpc_polling_interval))))
         } else {
             Ok(Some(BlockSourceConfig::local(value.into())))
         }

--- a/src/pseudo_peer/mod.rs
+++ b/src/pseudo_peer/mod.rs
@@ -43,6 +43,7 @@ pub async fn start_pseudo_peer(
     destination_peer: String,
     block_source: BlockSourceBoxed,
     debug_cutoff_height: Option<u64>,
+    db_block_number: Option<DbBlockNumberFn>,
 ) -> eyre::Result<()> {
     let blockhash_cache = new_blockhash_cache();
 
@@ -70,7 +71,8 @@ pub async fn start_pseudo_peer(
     let mut network_events = network_handle.event_listener();
     info!("Starting network manager...");
 
-    let mut service = PseudoPeer::new(chain_spec, block_source, blockhash_cache.clone());
+    let mut service =
+        PseudoPeer::new(chain_spec, block_source, blockhash_cache.clone(), db_block_number);
     tokio::spawn(network);
 
     // Directly add the main node as a peer (bypasses discovery)

--- a/src/pseudo_peer/mod.rs
+++ b/src/pseudo_peer/mod.rs
@@ -32,7 +32,10 @@ pub mod prelude {
 }
 
 use crate::chainspec::HlChainSpec;
+use reth_discv4::NodeRecord;
 use reth_network::{NetworkEvent, NetworkEventListenerProvider};
+use reth_network_api::Peers;
+use std::str::FromStr;
 
 /// Main function that starts the network manager and processes eth requests
 pub async fn start_pseudo_peer(
@@ -43,10 +46,13 @@ pub async fn start_pseudo_peer(
 ) -> eyre::Result<()> {
     let blockhash_cache = new_blockhash_cache();
 
-    // Create network manager
+    // Parse the destination peer enode string
+    let node_record = NodeRecord::from_str(&destination_peer)
+        .map_err(|e| eyre::eyre!("Failed to parse destination peer: {e}"))?;
+
+    // Create network manager (no boot_nodes — we add the peer directly)
     let (mut network, start_tx) = create_network_manager::<BlockSourceBoxed>(
         (*chain_spec).clone(),
-        destination_peer,
         block_source.clone(),
         blockhash_cache.clone(),
         debug_cutoff_height,
@@ -66,6 +72,15 @@ pub async fn start_pseudo_peer(
 
     let mut service = PseudoPeer::new(chain_spec, block_source, blockhash_cache.clone());
     tokio::spawn(network);
+
+    // Directly add the main node as a peer (bypasses discovery)
+    info!(
+        peer_id = %node_record.id,
+        addr = %node_record.tcp_addr(),
+        "Adding main node as direct peer"
+    );
+    network_handle.add_trusted_peer(node_record.id, node_record.tcp_addr());
+
     let mut first = true;
 
     // Main event loop

--- a/src/pseudo_peer/mod.rs
+++ b/src/pseudo_peer/mod.rs
@@ -25,7 +25,9 @@ pub mod prelude {
     pub use super::{
         config::BlockSourceConfig,
         service::{BlockPoller, PseudoPeer},
-        sources::{BlockSource, CachedBlockSource, LocalBlockSource, RpcBlockSource, S3BlockSource},
+        sources::{
+            BlockSource, CachedBlockSource, LocalBlockSource, RpcBlockSource, S3BlockSource,
+        },
     };
 }
 

--- a/src/pseudo_peer/network.rs
+++ b/src/pseudo_peer/network.rs
@@ -4,11 +4,9 @@ use reth_network::{
     NetworkConfig, NetworkManager, PeersConfig,
     config::{SecretKey, rng_secret_key},
 };
-use reth_network_peers::TrustedPeer;
 use reth_provider::test_utils::NoopProvider;
 use std::{
     net::{Ipv4Addr, SocketAddr},
-    str::FromStr,
     sync::Arc,
 };
 use tokio::sync::mpsc;
@@ -16,7 +14,6 @@ use tokio::sync::mpsc;
 pub struct NetworkBuilder {
     secret: SecretKey,
     peer_config: PeersConfig,
-    boot_nodes: Vec<TrustedPeer>,
     discovery_port: u16,
     listener_port: u16,
     chain_spec: HlChainSpec,
@@ -27,8 +24,7 @@ impl Default for NetworkBuilder {
     fn default() -> Self {
         Self {
             secret: rng_secret_key(),
-            peer_config: PeersConfig::default().with_max_outbound(1).with_max_inbound(1),
-            boot_nodes: vec![],
+            peer_config: PeersConfig::default().with_max_outbound(1).with_max_inbound(0),
             discovery_port: 0,
             listener_port: 0,
             chain_spec: HlChainSpec::default(),
@@ -38,11 +34,6 @@ impl Default for NetworkBuilder {
 }
 
 impl NetworkBuilder {
-    pub fn with_boot_nodes(mut self, boot_nodes: Vec<TrustedPeer>) -> Self {
-        self.boot_nodes = boot_nodes;
-        self
-    }
-
     pub fn with_chain_spec(mut self, chain_spec: HlChainSpec) -> Self {
         self.chain_spec = chain_spec;
         self
@@ -59,10 +50,11 @@ impl NetworkBuilder {
         blockhash_cache: BlockHashCache,
     ) -> eyre::Result<(NetworkManager<HlNetworkPrimitives>, mpsc::Sender<()>)> {
         let builder = NetworkConfig::<(), HlNetworkPrimitives>::builder(self.secret)
-            .boot_nodes(self.boot_nodes)
             .peer_config(self.peer_config)
             .discovery_addr(SocketAddr::new(Ipv4Addr::LOCALHOST.into(), self.discovery_port))
-            .listener_addr(SocketAddr::new(Ipv4Addr::LOCALHOST.into(), self.listener_port));
+            .listener_addr(SocketAddr::new(Ipv4Addr::LOCALHOST.into(), self.listener_port))
+            .disable_discv4_discovery()
+            .disable_dns_discovery();
         let chain_id = self.chain_spec.inner.chain().id();
 
         let (block_poller, start_tx) = BlockPoller::new_suspended(
@@ -85,13 +77,11 @@ impl NetworkBuilder {
 
 pub async fn create_network_manager<BS>(
     chain_spec: HlChainSpec,
-    destination_peer: String,
     block_source: Arc<Box<dyn super::sources::BlockSource>>,
     blockhash_cache: BlockHashCache,
     debug_cutoff_height: Option<u64>,
 ) -> eyre::Result<(NetworkManager<HlNetworkPrimitives>, mpsc::Sender<()>)> {
     NetworkBuilder::default()
-        .with_boot_nodes(vec![TrustedPeer::from_str(&destination_peer).unwrap()])
         .with_chain_spec(chain_spec)
         .with_debug_cutoff_height(debug_cutoff_height)
         .build::<BS>(block_source, blockhash_cache)

--- a/src/pseudo_peer/service.rs
+++ b/src/pseudo_peer/service.rs
@@ -8,7 +8,6 @@ use crate::{
 };
 use alloy_eips::HashOrNumber;
 use alloy_primitives::{B256, U128};
-use alloy_rpc_types::Block;
 use parking_lot::RwLock;
 use rayon::prelude::*;
 use reth_eth_wire::{
@@ -21,17 +20,16 @@ use reth_network::{
 };
 use reth_network_peers::PeerId;
 use std::{
-    collections::{HashMap, HashSet},
     pin::Pin,
-    sync::{Arc, Mutex},
+    sync::Arc,
     task::{Context, Poll},
 };
 use tokio::{sync::mpsc, task::JoinHandle};
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 /// A cache of block hashes to block numbers.
 pub type BlockHashCache = Arc<RwLock<LruBiMap<B256, u64>>>;
-const BLOCKHASH_CACHE_LIMIT: u32 = 1000000;
+const BLOCKHASH_CACHE_LIMIT: u32 = 1_000_000;
 
 pub fn new_blockhash_cache() -> BlockHashCache {
     Arc::new(RwLock::new(LruBiMap::new(BLOCKHASH_CACHE_LIMIT)))
@@ -122,17 +120,20 @@ impl BlockImport<HlNewBlock> for BlockPoller {
     fn on_new_block(&mut self, _peer_id: PeerId, _incoming_block: NewBlockEvent<HlNewBlock>) {}
 }
 
+/// Function that resolves a block hash to its number via the node's database.
+/// Returns `None` if the hash is not yet in the database (e.g. headers not synced yet).
+pub type DbBlockNumberFn = Arc<dyn Fn(B256) -> Option<u64> + Send + Sync>;
+
 /// A pseudo peer that can process eth requests and feed blocks to reth
 pub struct PseudoPeer<BS: BlockSource> {
     chain_spec: Arc<HlChainSpec>,
     block_source: BS,
     blockhash_cache: BlockHashCache,
-    warm_cache_size: u64,
-    if_hit_then_warm_around: Arc<Mutex<HashSet<u64>>>,
 
-    /// This is used to avoid calling `find_latest_block_number` too often.
-    /// Only used for cache warmup.
-    known_latest_block_number: u64,
+    /// Database lookup for hash→number resolution.
+    /// Reads directly from the node's header database, avoiding expensive
+    /// block source scans.
+    db_block_number: Option<DbBlockNumberFn>,
 }
 
 impl<BS: BlockSource> PseudoPeer<BS> {
@@ -140,14 +141,13 @@ impl<BS: BlockSource> PseudoPeer<BS> {
         chain_spec: Arc<HlChainSpec>,
         block_source: BS,
         blockhash_cache: BlockHashCache,
+        db_block_number: Option<DbBlockNumberFn>,
     ) -> Self {
         Self {
             chain_spec,
             block_source,
             blockhash_cache,
-            warm_cache_size: 1000, // reth default chunk size for GetBlockBodies
-            if_hit_then_warm_around: Arc::new(Mutex::new(HashSet::new())),
-            known_latest_block_number: 0,
+            db_block_number,
         }
     }
 
@@ -174,21 +174,39 @@ impl<BS: BlockSource> PseudoPeer<BS> {
                     "GetBlockHeaders request: {start_block:?}, {limit:?}, {skip:?}, {direction:?}"
                 );
                 let number = match start_block {
-                    HashOrNumber::Hash(hash) => self.hash_to_block_number(hash).await,
+                    HashOrNumber::Hash(hash) => match self.hash_to_block_number(hash).await {
+                        Ok(n) => n,
+                        Err(e) => {
+                            warn!("Failed to resolve block hash {hash:?}: {e}");
+                            let _ = response.send(Ok(BlockHeaders(vec![])));
+                            return Ok(());
+                        }
+                    },
                     HashOrNumber::Number(number) => number,
                 };
 
-                let block_headers = match direction {
+                let blocks = match direction {
                     HeadersDirection::Rising => self.collect_blocks(number..number + limit).await,
                     HeadersDirection::Falling => {
                         self.collect_blocks((number + 1 - limit..number + 1).rev()).await
                     }
-                }?
-                .into_par_iter()
-                .map(|block| block.to_reth_block(chain_id).header.clone())
-                .collect::<Vec<_>>();
+                }?;
 
-                let _ = response.send(Ok(BlockHeaders(block_headers)));
+                // Cache hash→number mappings so the Bodies stage can resolve them later
+                let block_headers: Vec<_> = blocks
+                    .into_par_iter()
+                    .map(|block| {
+                        let number = block.number();
+                        let reth_block = block.to_reth_block(chain_id);
+                        let hash = reth_block.header.hash_slow();
+                        (hash, number, reth_block.header.clone())
+                    })
+                    .collect();
+
+                self.cache_blocks(block_headers.iter().map(|(hash, number, _)| (*hash, *number)));
+
+                let headers = block_headers.into_iter().map(|(_, _, h)| h).collect();
+                let _ = response.send(Ok(BlockHeaders(headers)));
             }
             IncomingEthRequest::GetBlockBodies { peer_id: _, request, response } => {
                 let GetBlockBodies(hashes) = request;
@@ -196,7 +214,10 @@ impl<BS: BlockSource> PseudoPeer<BS> {
 
                 let mut numbers = Vec::new();
                 for hash in hashes {
-                    numbers.push(self.hash_to_block_number(hash).await);
+                    match self.hash_to_block_number(hash).await {
+                        Ok(n) => numbers.push(n),
+                        Err(e) => warn!("Failed to resolve block hash {hash:?}: {e}"),
+                    }
                 }
 
                 let block_bodies = self
@@ -214,152 +235,21 @@ impl<BS: BlockSource> PseudoPeer<BS> {
         Ok(())
     }
 
-    async fn hash_to_block_number(&mut self, hash: B256) -> u64 {
-        // First, try to find the hash in our cache
-        if let Some(block_number) = self.try_get_cached_block_number(hash).await {
-            return block_number;
+    async fn hash_to_block_number(&self, hash: B256) -> eyre::Result<u64> {
+        // Fast path: check in-memory cache
+        if let Some(block_number) = self.blockhash_cache.read().get_by_left(&hash).copied() {
+            return Ok(block_number);
         }
 
-        let latest = self.block_source.find_latest_block_number().await.unwrap();
-        self.known_latest_block_number = latest;
-
-        // These constants are quite arbitrary but works well in practice
-        const BACKFILL_RETRY_LIMIT: u64 = 10;
-
-        for _ in 0..BACKFILL_RETRY_LIMIT {
-            // If not found, backfill the cache and retry
-            if let Ok(Some(block_number)) = self.backfill_cache_for_hash(hash, latest).await {
-                return block_number;
-            }
-        }
-
-        panic!("Hash not found: {hash:?}");
-    }
-
-    async fn fallback_to_official_rpc(&self, hash: B256) -> eyre::Result<u64> {
-        // This is tricky because Raw EVM files (BlockSource) does not have hash to number mapping
-        // so we can either enumerate all blocks to get hash to number mapping, or fallback to an
-        // official RPC. The latter is much easier but has 300/day rate limit.
-        use jsonrpsee::http_client::HttpClientBuilder;
-        use jsonrpsee_core::client::ClientT;
-
-        debug!("Fallback to official RPC: {hash:?}");
-        let client =
-            HttpClientBuilder::default().build(self.chain_spec.official_rpc_url()).unwrap();
-        let target_block: Block = client.request("eth_getBlockByHash", (hash, false)).await?;
-        debug!("From official RPC: {:?} for {hash:?}", target_block.header.number);
-        self.cache_blocks([(hash, target_block.header.number)]);
-        Ok(target_block.header.number)
-    }
-
-    /// Try to get a block number from the cache for the given hash
-    async fn try_get_cached_block_number(&mut self, hash: B256) -> Option<u64> {
-        let maybe_block_number = self.blockhash_cache.read().get_by_left(&hash).copied();
-        if let Some(block_number) = maybe_block_number {
-            if self.if_hit_then_warm_around.lock().unwrap().contains(&block_number) {
-                self.warm_cache_around_blocks(block_number, self.warm_cache_size).await;
-            }
-            Some(block_number)
-        } else {
-            None
-        }
-    }
-
-    /// Backfill the cache with blocks to find the target hash
-    async fn backfill_cache_for_hash(
-        &mut self,
-        target_hash: B256,
-        latest: u64,
-    ) -> eyre::Result<Option<u64>> {
-        let chunk_size = self.block_source.recommended_chunk_size();
-        debug!("Hash not found, backfilling... {target_hash:?}");
-
-        const TRY_OFFICIAL_RPC_THRESHOLD: usize = 20;
-        for (iteration, end) in (1..=latest).rev().step_by(chunk_size as usize).enumerate() {
-            // Calculate the range to backfill
-            let start = std::cmp::max(end.saturating_sub(chunk_size), 1);
-
-            // Backfill this chunk
-            if let Ok(Some(block_number)) =
-                self.try_block_range_for_hash(start, end, target_hash).await
-            {
-                return Ok(Some(block_number));
-            }
-
-            // If not found, first fallback to an official RPC
-            if iteration >= TRY_OFFICIAL_RPC_THRESHOLD {
-                match self.fallback_to_official_rpc(target_hash).await {
-                    Ok(block_number) => {
-                        self.warm_cache_around_blocks(block_number, self.warm_cache_size).await;
-                        return Ok(Some(block_number));
-                    }
-                    Err(e) => {
-                        debug!("Fallback to official RPC failed: {e:?}");
-                    }
-                }
-            }
-        }
-
-        debug!("Hash not found: {target_hash:?}, retrying from the latest block...");
-        Ok(None) // Not found
-    }
-
-    async fn warm_cache_around_blocks(&mut self, block_number: u64, chunk_size: u64) {
-        let start = std::cmp::max(block_number.saturating_sub(chunk_size), 1);
-        let end = std::cmp::min(block_number + chunk_size, self.known_latest_block_number);
+        // Look up in the node's database (all headers are stored after the Headers stage)
+        if let Some(ref db_fn) = self.db_block_number
+            && let Some(block_number) = db_fn(hash)
         {
-            let mut guard = self.if_hit_then_warm_around.lock().unwrap();
-            guard.insert(start);
-            guard.insert(end);
-        }
-        const IMPOSSIBLE_HASH: B256 = B256::ZERO;
-        let _ = self.try_block_range_for_hash(start, end, IMPOSSIBLE_HASH).await;
-    }
-
-    /// Backfill a specific range of block numbers into the cache
-    async fn try_block_range_for_hash(
-        &mut self,
-        start_number: u64,
-        end_number: u64,
-        target_hash: B256,
-    ) -> eyre::Result<Option<u64>> {
-        // Get block numbers that are already cached
-        let (cached_block_hashes, uncached_block_numbers) =
-            self.get_cached_block_hashes(start_number, end_number);
-
-        if let Some(&block_number) = cached_block_hashes.get(&target_hash) {
-            return Ok(Some(block_number));
+            self.cache_blocks([(hash, block_number)]);
+            return Ok(block_number);
         }
 
-        if uncached_block_numbers.is_empty() {
-            debug!("All blocks are cached, returning None");
-            return Ok(None);
-        }
-
-        debug!("Backfilling from {start_number} to {end_number}");
-        // Collect blocks and cache them
-        let blocks = self.collect_blocks(uncached_block_numbers).await?;
-        let block_map: HashMap<B256, u64> =
-            blocks.into_iter().map(|block| (block.hash(), block.number())).collect();
-        let maybe_block_number = block_map.get(&target_hash).copied();
-        self.cache_blocks(block_map);
-        Ok(maybe_block_number)
-    }
-
-    /// Get block numbers in the range that are already cached
-    fn get_cached_block_hashes(
-        &self,
-        start_number: u64,
-        end_number: u64,
-    ) -> (HashMap<B256, u64>, Vec<u64>) {
-        let map = self.blockhash_cache.read();
-        let (cached, uncached): (Vec<u64>, Vec<u64>) =
-            (start_number..=end_number).partition(|number| map.get_by_right(number).is_some());
-        let cached_block_hashes = cached
-            .into_iter()
-            .filter_map(|number| map.get_by_right(&number).map(|&hash| (hash, number)))
-            .collect();
-        (cached_block_hashes, uncached)
+        Err(eyre::eyre!("Hash not found in cache or database: {hash:?}"))
     }
 
     /// Cache a collection of blocks in the hash-to-number mapping

--- a/src/pseudo_peer/sources/cached.rs
+++ b/src/pseudo_peer/sources/cached.rs
@@ -2,7 +2,10 @@ use super::{BlockSource, BlockSourceBoxed};
 use crate::node::types::BlockAndReceipts;
 use futures::{FutureExt, future::BoxFuture};
 use reth_network::cache::LruMap;
-use std::{collections::HashMap, sync::{Arc, RwLock}};
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
 
 /// Block source wrapper that caches blocks in memory
 #[derive(Debug, Clone)]
@@ -77,11 +80,7 @@ impl BlockSource for CachedBlockSource {
             // Return in original order
             heights
                 .iter()
-                .map(|h| {
-                    cached
-                        .remove(h)
-                        .ok_or_else(|| eyre::eyre!("Block {h} not found"))
-                })
+                .map(|h| cached.remove(h).ok_or_else(|| eyre::eyre!("Block {h} not found")))
                 .collect()
         }
         .boxed()

--- a/src/pseudo_peer/sources/rpc.rs
+++ b/src/pseudo_peer/sources/rpc.rs
@@ -35,7 +35,11 @@ impl RpcBlockSource {
             .build(&url)
             .unwrap_or_else(|e| panic!("Failed to build RPC client for {url}: {e}"));
         info!("RPC block source connected to {url}");
-        Self { client: Arc::new(client), polling_interval, metrics: RpcBlockSourceMetrics::default() }
+        Self {
+            client: Arc::new(client),
+            polling_interval,
+            metrics: RpcBlockSourceMetrics::default(),
+        }
     }
 }
 
@@ -75,29 +79,24 @@ impl BlockSource for RpcBlockSource {
             const BATCH_SIZE: usize = 500;
             const MAX_CONCURRENT_BATCHES: usize = 20;
 
-            let batches: Vec<Vec<u64>> =
-                heights.chunks(BATCH_SIZE).map(|c| c.to_vec()).collect();
+            let batches: Vec<Vec<u64>> = heights.chunks(BATCH_SIZE).map(|c| c.to_vec()).collect();
 
-            let results: Vec<eyre::Result<Vec<BlockAndReceipts>>> =
-                futures::stream::iter(batches)
-                    .map(|batch| {
-                        let client = client.clone();
-                        let metrics = metrics.clone();
-                        async move {
-                            metrics.polling_attempt.increment(batch.len() as u64);
-                            let bytes: Bytes =
-                                client.request("hl_syncGetBlocks", (batch,)).await?;
-                            let mut decoder =
-                                lz4_flex::frame::FrameDecoder::new(&bytes[..]);
-                            let blocks: Vec<BlockAndReceipts> =
-                                rmp_serde::from_read(&mut decoder)?;
-                            metrics.fetched.increment(blocks.len() as u64);
-                            Ok(blocks)
-                        }
-                    })
-                    .buffered(MAX_CONCURRENT_BATCHES)
-                    .collect()
-                    .await;
+            let results: Vec<eyre::Result<Vec<BlockAndReceipts>>> = futures::stream::iter(batches)
+                .map(|batch| {
+                    let client = client.clone();
+                    let metrics = metrics.clone();
+                    async move {
+                        metrics.polling_attempt.increment(batch.len() as u64);
+                        let bytes: Bytes = client.request("hl_syncGetBlocks", (batch,)).await?;
+                        let mut decoder = lz4_flex::frame::FrameDecoder::new(&bytes[..]);
+                        let blocks: Vec<BlockAndReceipts> = rmp_serde::from_read(&mut decoder)?;
+                        metrics.fetched.increment(blocks.len() as u64);
+                        Ok(blocks)
+                    }
+                })
+                .buffered(MAX_CONCURRENT_BATCHES)
+                .collect()
+                .await;
 
             let mut all_blocks = Vec::with_capacity(heights.len());
             for result in results {


### PR DESCRIPTION
## Summary

### 1. `style: cargo fmt and clippy fixes`
Formatting and `collapsible_if` lint fixes, no functional changes.

### 2. `refactor: use direct trusted peer instead of boot node discovery`
- Remove boot nodes and discovery (discv4/DNS) — the pseudo-peer always connects to a known local node, so discovery is unnecessary
- Use `add_trusted_peer` instead of `add_peer` so the peer auto-reconnects on disconnect and is never evicted after backoff failures
- Set `max_inbound(0)` since only one outbound connection is needed

### 3. `refactor: resolve hash→number via node DB instead of backfill scanning`
- Pass a `DbBlockNumberFn` closure from `build_network` into the pseudo-peer for direct hash→number lookups against the node's header DB
- Remove ~200 lines of backfill/cache-warming code (`backfill_cache_for_hash`, `warm_cache_around_blocks`, `try_block_range_for_hash`, `get_cached_block_hashes`, `fallback_to_official_rpc`, watermarks, retry loop)
- LRU cache (1M entries) remains as a fast-path to avoid DB roundtrips

This resolves #109 

## Test plan
- [x] Full sync completes without hash resolution errors
- [x] Pseudo-peer reconnects after main node disconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)