### PR TITLE
perf(s3): use spawn-based fetcher for S3 block source

### DIFF
--- a/src/pseudo_peer/sources/s3.rs
+++ b/src/pseudo_peer/sources/s3.rs
@@ -105,6 +105,38 @@ impl BlockSource for S3BlockSource {
         .boxed()
     }
 
+    /// Uses `tokio::spawn` batches instead of the default `buffered()` stream.
+    /// This distributes response processing across the runtime's thread pool,
+    /// avoiding the single-task polling bottleneck (~10x faster on fast networks).
+    fn collect_blocks(
+        &self,
+        heights: Vec<u64>,
+    ) -> BoxFuture<'static, eyre::Result<Vec<BlockAndReceipts>>> {
+        let concurrency = self.recommended_chunk_size() as usize;
+        let futs: Vec<_> = heights
+            .into_iter()
+            .map(|h| self.collect_block(h))
+            .collect();
+        async move {
+            let mut results = Vec::with_capacity(futs.len());
+            let mut futs = futs.into_iter();
+            loop {
+                let batch: Vec<_> = (&mut futs)
+                    .take(concurrency)
+                    .map(|fut| tokio::spawn(fut))
+                    .collect();
+                if batch.is_empty() {
+                    break;
+                }
+                for handle in batch {
+                    results.push(handle.await.map_err(|e| eyre::eyre!(e))??);
+                }
+            }
+            Ok(results)
+        }
+        .boxed()
+    }
+
     fn recommended_chunk_size(&self) -> u64 {
         1000
     }


### PR DESCRIPTION
## Summary
- Override `collect_blocks` on `S3BlockSource` with `tokio::spawn` batches instead of the default `buffered()` stream
- Avoids single-task polling bottleneck, yielding ~10x speedup on fast networks (4s -> 3.1s in slow network, -> 0.3s in fast network per 10K blocks in testnet)
- Keeps `buffered()` as the default trait impl (better for filesystem and other sources)
- Both approaches result in the same number of file descriptors — hyper's connection pool opens sockets based on concurrent requests regardless of whether they're driven by `buffered()` or `tokio::spawn`

## Test plan
- [x] Verify S3 block fetching performance on fast network
- [x] Verify local/hl_node block sources are unaffected (still use default `buffered()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)