### PR TITLE
ci(release): create GitHub releases as drafts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,5 +88,6 @@ jobs:
           tag_name: ${{ github.ref_name }}
           files: ${{ steps.gather.outputs.files }}
           generate_release_notes: true
+          draft: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Set `draft: true` on the GitHub release step so releases are created as drafts for review before publishing

## Test plan
- [ ] Trigger a release and verify it appears as a draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)