### PR TITLE
Fix trace_block HL precompile setup

### DIFF
--- a/src/node/rpc/mod.rs
+++ b/src/node/rpc/mod.rs
@@ -3,10 +3,12 @@ use crate::{
     chainspec::HlChainSpec,
     node::{evm::apply_precompiles, types::HlExtras},
 };
+use alloy_consensus::{BlockHeader, transaction::TxHashRef};
 use alloy_eips::BlockId;
-use alloy_evm::Evm;
+use alloy_evm::{Evm, EvmFactory};
 use alloy_network::Ethereum;
 use alloy_primitives::U256;
+use alloy_rpc_types_eth::TransactionInfo;
 use reth::{
     api::{FullNodeTypes, HeaderTy, NodeTypes, PrimitivesTy},
     builder::{
@@ -25,21 +27,28 @@ use reth::{
         pool::{BlockingTaskGuard, BlockingTaskPool},
     },
 };
-use reth_evm::{ConfigureEvm, Database, EvmEnvFor, HaltReasonFor, InspectorFor, TxEnvFor};
+use reth_evm::{
+    ConfigureEvm, Database, EvmEnvFor, EvmFor, HaltReasonFor, InspectorFor, TxEnvFor,
+    tracing::{TracingCtx, TxTracer},
+};
 use reth_primitives::NodePrimitives;
+use reth_primitives_traits::{BlockBody, Recovered, RecoveredBlock};
 use reth_provider::{
     BlockReaderIdExt, ChainSpecProvider, ProviderError, ProviderHeader, ProviderTx,
 };
+use reth_revm::{database::StateProviderDatabase, db::CacheDB};
 use reth_rpc::RpcTypes;
 use reth_rpc_eth_api::{
     EthApiTypes, FromEvmError, RpcConvert, RpcConverter, RpcNodeCore, RpcNodeCoreExt,
     SignableTxRequest,
     helpers::{
-        AddDevSigners, EthApiSpec, EthFees, EthState, LoadFee, LoadPendingBlock, LoadState,
-        SpawnBlocking, Trace, pending_block::BuildPendingEnv, spec::SignersForApi,
+        AddDevSigners, EthApiSpec, EthFees, EthState, LoadBlock, LoadFee, LoadPendingBlock,
+        LoadState, SpawnBlocking, Trace, pending_block::BuildPendingEnv, spec::SignersForApi,
     },
 };
-use revm::context::result::ResultAndState;
+use reth_rpc_eth_types::cache::db::{StateCacheDbRefMutWrapper, StateProviderTraitObjWrapper};
+use reth_storage_api::ProviderBlock;
+use revm::{DatabaseCommit, context::result::ResultAndState};
 use std::{fmt, marker::PhantomData, sync::Arc};
 
 mod block;
@@ -246,6 +255,106 @@ where
         let mut evm = self.evm_config().evm_with_env_and_inspector(db, evm_env, inspector);
         apply_precompiles(&mut evm, &hl_extras);
         evm.transact(tx_env).map_err(Self::Error::from_evm_err)
+    }
+
+    fn apply_pre_execution_changes<DB: Send + Database + DatabaseCommit>(
+        &self,
+        _block: &reth_primitives_traits::RecoveredBlock<
+            reth_storage_api::ProviderBlock<Self::Provider>,
+        >,
+        _db: &mut DB,
+        _evm_env: &EvmEnvFor<Self::Evm>,
+    ) -> Result<(), Self::Error> {
+        // HL dynamic precompiles are EVM-local, so they must be installed on the actual
+        // execution EVM rather than through this DB/env-only hook.
+        Ok(())
+    }
+
+    async fn trace_block_until_with_inspector<Setup, Insp, F, R>(
+        &self,
+        block_id: BlockId,
+        block: Option<Arc<RecoveredBlock<ProviderBlock<Self::Provider>>>>,
+        highest_index: Option<u64>,
+        mut inspector_setup: Setup,
+        f: F,
+    ) -> Result<Option<Vec<R>>, Self::Error>
+    where
+        Self: LoadBlock,
+        F: Fn(
+                TransactionInfo,
+                TracingCtx<
+                    '_,
+                    Recovered<&ProviderTx<Self::Provider>>,
+                    EvmFor<Self::Evm, StateCacheDbRefMutWrapper<'_, '_>, Insp>,
+                >,
+            ) -> Result<R, Self::Error>
+            + Send
+            + 'static,
+        Setup: FnMut() -> Insp + Send + 'static,
+        Insp: Clone + for<'a, 'b> InspectorFor<Self::Evm, StateCacheDbRefMutWrapper<'a, 'b>>,
+        R: Send + 'static,
+    {
+        let block = async {
+            if block.is_some() {
+                return Ok(block);
+            }
+            self.recovered_block(block_id).await
+        };
+
+        let ((evm_env, _), block) = futures::try_join!(self.evm_env_at(block_id), block)?;
+
+        let Some(block) = block else { return Ok(None) };
+
+        if block.body().transactions().is_empty() {
+            return Ok(Some(Vec::new()));
+        }
+
+        self.spawn_blocking_io_fut(move |this| async move {
+            let state_at = block.parent_hash();
+            let block_hash = block.hash();
+            let block_number = evm_env.block_env.number.saturating_to();
+            let base_fee = evm_env.block_env.basefee;
+            let hl_extras =
+                this.get_hl_extras(evm_env.block_env.number.to::<u64>().into()).map_err(
+                    |err: ProviderError| <EthApiError as From<ProviderError>>::from(err),
+                )?;
+
+            let state = this.state_at_block_id(state_at.into()).await?;
+            let mut db =
+                CacheDB::new(StateProviderDatabase::new(StateProviderTraitObjWrapper(&state)));
+
+            let max_transactions = highest_index.map_or_else(
+                || block.body().transaction_count(),
+                |highest| highest as usize + 1,
+            );
+
+            let mut idx = 0;
+            let mut evm = this.evm_config().evm_factory().create_evm_with_inspector(
+                StateCacheDbRefMutWrapper(&mut db),
+                evm_env,
+                inspector_setup(),
+            );
+            apply_precompiles(&mut evm, &hl_extras);
+            let mut tracer = TxTracer::new(evm);
+
+            let results = tracer
+                .try_trace_many(block.transactions_recovered().take(max_transactions), |ctx| {
+                    let tx_info = TransactionInfo {
+                        hash: Some(*ctx.tx.tx_hash()),
+                        index: Some(idx),
+                        block_hash: Some(block_hash),
+                        block_number: Some(block_number),
+                        base_fee: Some(base_fee),
+                    };
+                    idx += 1;
+
+                    f(tx_info, ctx)
+                })
+                .collect::<Result<_, _>>()?;
+
+            Ok(Some(results))
+        })
+        .await
     }
 }
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-export ETH_RPC_URL="${ETH_RPC_URL:-wss://hl-archive-node.xyz}"
-
 success() {
     echo "Success: $1"
 }
@@ -20,9 +18,25 @@ ensure_cmd() {
 ensure_cmd jq
 ensure_cmd cast
 ensure_cmd wscat
+ensure_cmd curl
 
-if [[ ! "$ETH_RPC_URL" =~ ^wss?:// ]]; then
-    fail "ETH_RPC_URL must be a websocket url"
+if [[ -z "${ETH_RPC_URL:-}" ]]; then
+    fail "ETH_RPC_URL must be set"
+fi
+
+if [[ -z "${TRACE_RPC_URL:-}" ]]; then
+    fail "TRACE_RPC_URL must be set"
+fi
+
+if [[ ! "$ETH_RPC_URL" =~ ^https?:// && ! "$ETH_RPC_URL" =~ ^wss?:// ]]; then
+    fail "ETH_RPC_URL must be an http(s) or ws(s) url"
+fi
+
+TRACE_RPC_URL="${TRACE_RPC_URL/wss:\/\//https:\/\/}"
+TRACE_RPC_URL="${TRACE_RPC_URL/ws:\/\//http:\/\/}"
+
+if [[ ! "$TRACE_RPC_URL" =~ ^https?:// ]]; then
+    fail "TRACE_RPC_URL must be an http(s) url"
 fi
 
 TITLE="Issue #78 - eth_getLogs should return system transactions"
@@ -44,6 +58,34 @@ echo rpc\  "$B"
 [[ "$A" == "$B" ]] && success "$TITLE" || fail "$TITLE"
 
 TITLE="eth_subscribe newHeads via wscat"
-CMD='{"jsonrpc":"2.0","id":1,"method":"eth_subscribe","params":["newHeads"]}'
-wscat -w 2 -c "$ETH_RPC_URL" -x "$CMD" | tail -1 | jq -r .params.result.nonce | grep 0x \
-    && success "$TITLE" || fail "$TITLE"
+if [[ "${WS_RPC_URL:-}" =~ ^wss?:// || "$ETH_RPC_URL" =~ ^wss?:// ]]; then
+    CMD='{"jsonrpc":"2.0","id":1,"method":"eth_subscribe","params":["newHeads"]}'
+    wscat -w 2 -c "${WS_RPC_URL:-$ETH_RPC_URL}" -x "$CMD" | tail -1 | jq -r .params.result.nonce | grep 0x \
+        && success "$TITLE" || fail "$TITLE"
+else
+    echo "Skipped: $TITLE - set WS_RPC_URL to test websocket subscriptions"
+fi
+
+TITLE="trace_block should include all txs for block 34922247"
+BLOCK=0x214df07
+MISSING_REVERTED=0x0a799b330359f9655b819627cdc4dd600bad255bdeaca51cc9d3c636edfe8b4f
+MISSING_SUCCESS=0xfefa762d83fda72df7a5d84d365502b663d83ffd5e138bef1cf0d54ed5779ede
+BLOCK_TX_COUNT=$(curl -sS -H 'content-type: application/json' \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"eth_getBlockByNumber\",\"params\":[\"$BLOCK\",false]}" \
+    "$ETH_RPC_URL" | jq -r '.result.transactions | length')
+[[ "$BLOCK_TX_COUNT" =~ ^[0-9]+$ ]] || fail "$TITLE - failed to fetch block tx count"
+TRACE_RESULT=$(curl -sS -H 'content-type: application/json' \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"trace_block\",\"params\":[\"$BLOCK\"]}" \
+    "$TRACE_RPC_URL")
+echo "$TRACE_RESULT" | jq -e \
+    --argjson expected "$BLOCK_TX_COUNT" \
+    --arg reverted "$MISSING_REVERTED" \
+    --arg success "$MISSING_SUCCESS" \
+    '
+    (.error | not) and
+    ([.result[]?.transactionHash] | unique) as $hashes |
+    ($hashes | length) == $expected and
+    ($hashes | index($reverted) != null) and
+    ($hashes | index($success) != null)
+    ' > /dev/null \
+    && success "$TITLE" || fail "$TITLE - trace_block missing expected tx hashes"


### PR DESCRIPTION
Resolves #132 

## Summary
- apply HyperEVM read precompiles during block trace replay
- align `trace_block` pre-execution setup with the single-transaction trace path
- fixes missing trailing traces when block replay hits an HL precompile-dependent transaction

## Repro
Customer-reported block `34922247` (`0x214df07`) has 7 txs, but `trace_block` returned traces only for the first 5. The missing txs were:
- `0x0a799b330359f9655b819627cdc4dd600bad255bdeaca51cc9d3c636edfe8b4f`
- `0xfefa762d83fda72df7a5d84d365502b663d83ffd5e138bef1cf0d54ed5779ede`

`debug_traceBlockByNumber` and `debug_traceTransaction` returned all traces because they use a different replay path.

## Verification
- `cargo check`

## Notes
There is still a separate upstream/alloy behavior where `try_trace_many` silently ends iteration on EVM execution error. This patch prevents the HL-specific replay error by installing the required precompiles, but the silent-truncation behavior should still be fixed upstream or in the reth fork.