### PR TITLE
Retry block source startup robustly

### DIFF
--- a/src/node/network/mod.rs
+++ b/src/node/network/mod.rs
@@ -32,9 +32,10 @@ use reth_storage_api::BlockNumReader;
 use std::{
     net::{Ipv4Addr, SocketAddr},
     sync::Arc,
+    time::{Duration, Instant},
 };
 use tokio::sync::{Mutex, mpsc, oneshot};
-use tracing::info;
+use tracing::{info, warn};
 
 pub mod block_import;
 
@@ -288,7 +289,11 @@ where
                 // via a direct forkchoice update. This must happen before
                 // start_pseudo_peer (which never returns).
                 // get_by_number auto-indexes the block's hash AND parent hash.
-                if let Some(latest) = block_store.find_latest_block_number().await {
+                let polling_interval = block_store.polling_interval();
+                let mut retry_interval = polling_interval;
+                let retry_started_at = Instant::now();
+                loop {
+                    let latest = block_store.wait_for_latest_block_number().await;
                     match block_store.get_by_number(latest).await {
                         Ok(block) => {
                             let hash = block.hash();
@@ -299,13 +304,22 @@ where
                                 "Sending forkchoice trigger from block source"
                             );
                             let _ = fcu_trigger_tx.send(hash);
+                            break;
                         }
                         Err(e) => {
-                            info!(
+                            warn!(
                                 target: "reth::cli",
                                 %e,
-                                "Failed to read latest block for forkchoice trigger"
+                                ?retry_interval,
+                                "Failed to read latest block for forkchoice trigger; retrying"
                             );
+                            tokio::time::sleep(retry_interval).await;
+                            if retry_started_at.elapsed() >= Duration::from_secs(2) {
+                                retry_interval =
+                                    retry_interval.saturating_mul(2).min(Duration::from_secs(30));
+                            } else {
+                                retry_interval = polling_interval;
+                            }
                         }
                     }
                 }

--- a/src/pseudo_peer/block_store.rs
+++ b/src/pseudo_peer/block_store.rs
@@ -7,9 +7,9 @@ use reth_network::cache::LruMap;
 use std::{
     collections::HashMap,
     sync::Arc,
-    time::Duration,
+    time::{Duration, Instant},
 };
-use tracing::info;
+use tracing::{info, warn};
 
 /// Function that resolves a block hash to its number via the node's database.
 /// Returns `None` if the hash is not yet in the database (e.g. headers not synced yet).
@@ -18,6 +18,8 @@ pub type DbBlockNumberFn = Arc<dyn Fn(B256) -> Option<u64> + Send + Sync>;
 
 const BLOCK_CACHE_LIMIT: u32 = 100_000;
 const HASH_INDEX_LIMIT: u32 = 1_000_000;
+const LATEST_BLOCK_RETRY_BACKOFF_AFTER: Duration = Duration::from_secs(2);
+const LATEST_BLOCK_RETRY_MAX_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Unified block store that combines block content caching, hash↔number indexing,
 /// and database fallback into a single abstraction.
@@ -165,11 +167,101 @@ impl BlockStore {
 
     // --- Delegated block source methods ---
 
-    pub fn find_latest_block_number(&self) -> BoxFuture<'static, Option<u64>> {
+    pub fn find_latest_block_number(&self) -> BoxFuture<'static, eyre::Result<Option<u64>>> {
         self.source.find_latest_block_number()
+    }
+
+    pub async fn wait_for_latest_block_number(&self) -> u64 {
+        let polling_interval = self.polling_interval();
+        let mut retry_interval = self.polling_interval();
+        let retry_started_at = Instant::now();
+        loop {
+            match self.find_latest_block_number().await {
+                Ok(Some(block_number)) => return block_number,
+                Ok(None) => {
+                    warn!(
+                        ?retry_interval,
+                        "No latest block available from block source; retrying"
+                    );
+                }
+                Err(err) => {
+                    warn!(
+                        ?retry_interval,
+                        ?err,
+                        "Failed to find latest block number from block source; retrying"
+                    );
+                }
+            }
+
+            tokio::time::sleep(retry_interval).await;
+            if retry_started_at.elapsed() >= LATEST_BLOCK_RETRY_BACKOFF_AFTER {
+                retry_interval = retry_interval
+                    .saturating_mul(2)
+                    .min(LATEST_BLOCK_RETRY_MAX_INTERVAL);
+            } else {
+                retry_interval = polling_interval;
+            }
+        }
     }
 
     pub fn polling_interval(&self) -> Duration {
         self.source.polling_interval()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        node::types::BlockAndReceipts,
+        pseudo_peer::sources::{BlockSource, BlockSourceBoxed},
+    };
+    use futures::{FutureExt, future::BoxFuture};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[derive(Debug)]
+    struct EventuallyLatestBlockSource {
+        attempts: Arc<AtomicUsize>,
+    }
+
+    impl BlockSource for EventuallyLatestBlockSource {
+        fn collect_block(&self, _height: u64) -> BoxFuture<'static, eyre::Result<BlockAndReceipts>> {
+            async { Err(eyre::eyre!("unused in this test")) }.boxed()
+        }
+
+        fn find_latest_block_number(&self) -> BoxFuture<'static, eyre::Result<Option<u64>>> {
+            let attempts = self.attempts.clone();
+            async move {
+                let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                match attempt {
+                    0 => Err(eyre::eyre!("temporary source error")),
+                    1 => Ok(None),
+                    _ => Ok(Some(42)),
+                }
+            }
+            .boxed()
+        }
+
+        fn recommended_chunk_size(&self) -> u64 {
+            1
+        }
+
+        fn polling_interval(&self) -> Duration {
+            Duration::from_millis(1)
+        }
+    }
+
+    #[tokio::test]
+    async fn wait_for_latest_block_number_retries_until_available() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let source: BlockSourceBoxed = Arc::new(Box::new(EventuallyLatestBlockSource {
+            attempts: attempts.clone(),
+        }));
+        let store = BlockStore::new(source, None, 999);
+
+        let latest = store.wait_for_latest_block_number().await;
+
+        assert_eq!(latest, 42);
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
     }
 }

--- a/src/pseudo_peer/service.rs
+++ b/src/pseudo_peer/service.rs
@@ -63,23 +63,14 @@ impl BlockPoller {
         info!("Starting block poller");
 
         let polling_interval = block_store.polling_interval();
-        let mut next_block_number = loop {
-            if let Some(block_number) = block_store.find_latest_block_number().await {
-                break block_number;
-            }
-
-            warn!(
-                "Failed to find latest block number from block source; retrying in {:?}",
-                polling_interval
-            );
-            tokio::time::sleep(polling_interval).await;
-        };
+        let mut next_block_number = block_store.wait_for_latest_block_number().await;
 
         loop {
             if let Some(debug_cutoff_height) = debug_cutoff_height
                 && next_block_number > debug_cutoff_height
             {
-                next_block_number = debug_cutoff_height;
+                tokio::time::sleep(polling_interval).await;
+                continue;
             }
 
             match block_store.get_by_number(next_block_number).await {

--- a/src/pseudo_peer/sources/hl_node/mod.rs
+++ b/src/pseudo_peer/sources/hl_node/mod.rs
@@ -91,7 +91,7 @@ impl BlockSource for HlNodeBlockSource {
         })
     }
 
-    fn find_latest_block_number(&self) -> BoxFuture<'static, Option<u64>> {
+    fn find_latest_block_number(&self) -> BoxFuture<'static, eyre::Result<Option<u64>>> {
         let fallback = self.fallback.clone();
         let args = self.args.clone();
         Box::pin(async move {
@@ -106,7 +106,7 @@ impl BlockSource for HlNodeBlockSource {
             match FileOperations::read_last_block_from_file(&dir) {
                 Some((_, height)) => {
                     info!("Latest block number: {} with path {}", height, dir.display());
-                    Some(height)
+                    Ok(Some(height))
                 }
                 None => {
                     warn!(

--- a/src/pseudo_peer/sources/local.rs
+++ b/src/pseudo_peer/sources/local.rs
@@ -27,15 +27,19 @@ impl LocalBlockSource {
         Self { dir: dir.into(), metrics: LocalBlockSourceMetrics::default() }
     }
 
-    async fn pick_path_with_highest_number(dir: PathBuf, is_dir: bool) -> Option<(u64, String)> {
-        let files = std::fs::read_dir(&dir).unwrap().collect::<Vec<_>>();
+    async fn pick_path_with_highest_number(
+        dir: PathBuf,
+        is_dir: bool,
+    ) -> eyre::Result<Option<(u64, String)>> {
+        let files = std::fs::read_dir(&dir)?.collect::<Vec<_>>();
         let files = files
             .into_iter()
-            .filter(|path| path.as_ref().unwrap().path().is_dir() == is_dir)
-            .map(|entry| entry.unwrap().path().to_string_lossy().to_string())
+            .filter_map(Result::ok)
+            .filter(|path| path.path().is_dir() == is_dir)
+            .map(|entry| entry.path().to_string_lossy().to_string())
             .collect::<Vec<_>>();
 
-        utils::name_with_largest_number(&files, is_dir)
+        Ok(utils::name_with_largest_number(&files, is_dir))
     }
 }
 
@@ -58,17 +62,27 @@ impl BlockSource for LocalBlockSource {
         .boxed()
     }
 
-    fn find_latest_block_number(&self) -> BoxFuture<'static, Option<u64>> {
+    fn find_latest_block_number(&self) -> BoxFuture<'static, eyre::Result<Option<u64>>> {
         let dir = self.dir.clone();
         async move {
-            let (_, first_level) = Self::pick_path_with_highest_number(dir.clone(), true).await?;
-            let (_, second_level) =
-                Self::pick_path_with_highest_number(dir.join(first_level), true).await?;
-            let (block_number, third_level) =
-                Self::pick_path_with_highest_number(dir.join(second_level), false).await?;
+            let Some((_, first_level)) =
+                Self::pick_path_with_highest_number(dir.clone(), true).await?
+            else {
+                return Ok(None);
+            };
+            let Some((_, second_level)) =
+                Self::pick_path_with_highest_number(dir.join(first_level), true).await?
+            else {
+                return Ok(None);
+            };
+            let Some((block_number, third_level)) =
+                Self::pick_path_with_highest_number(dir.join(second_level), false).await?
+            else {
+                return Ok(None);
+            };
 
             info!("Latest block number: {} with path {}", block_number, third_level);
-            Some(block_number)
+            Ok(Some(block_number))
         }
         .boxed()
     }

--- a/src/pseudo_peer/sources/mod.rs
+++ b/src/pseudo_peer/sources/mod.rs
@@ -25,7 +25,7 @@ pub trait BlockSource: Send + Sync + std::fmt::Debug + Unpin + 'static {
     fn collect_block(&self, height: u64) -> BoxFuture<'static, eyre::Result<BlockAndReceipts>>;
 
     /// Finds the latest block number available from this source
-    fn find_latest_block_number(&self) -> BoxFuture<'static, Option<u64>>;
+    fn find_latest_block_number(&self) -> BoxFuture<'static, eyre::Result<Option<u64>>>;
 
     /// Returns the recommended chunk size for batch operations
     fn recommended_chunk_size(&self) -> u64;

--- a/src/pseudo_peer/sources/rpc.rs
+++ b/src/pseudo_peer/sources/rpc.rs
@@ -58,13 +58,13 @@ impl BlockSource for RpcBlockSource {
         .boxed()
     }
 
-    fn find_latest_block_number(&self) -> BoxFuture<'static, Option<u64>> {
+    fn find_latest_block_number(&self) -> BoxFuture<'static, eyre::Result<Option<u64>>> {
         let client = self.client.clone();
         async move {
             let result: Option<u64> =
-                client.request("hl_syncLatestBlockNumber", Vec::<u64>::new()).await.ok()?;
+                client.request("hl_syncLatestBlockNumber", Vec::<u64>::new()).await?;
             info!("Latest block number from remote: {:?}", result);
-            result
+            Ok(result)
         }
         .boxed()
     }

--- a/src/pseudo_peer/sources/s3.rs
+++ b/src/pseudo_peer/sources/s3.rs
@@ -39,28 +39,30 @@ impl S3BlockSource {
         bucket: &str,
         dir: &str,
         is_dir: bool,
-    ) -> Option<(u64, String)> {
+    ) -> eyre::Result<Option<(u64, String)>> {
         let request = client
             .list_objects()
             .bucket(bucket)
             .prefix(dir)
             .delimiter("/")
             .request_payer(RequestPayer::Requester);
-        let response = request.send().await.ok()?;
+        let response = request.send().await?;
         let files: Vec<String> = if is_dir {
             response
-                .common_prefixes?
+                .common_prefixes
+                .unwrap_or_default()
                 .iter()
-                .map(|object| object.prefix.as_ref().unwrap().to_string())
+                .filter_map(|object| object.prefix.as_ref().map(ToString::to_string))
                 .collect()
         } else {
             response
-                .contents?
+                .contents
+                .unwrap_or_default()
                 .iter()
-                .map(|object| object.key.as_ref().unwrap().to_string())
+                .filter_map(|object| object.key.as_ref().map(ToString::to_string))
                 .collect()
         };
-        utils::name_with_largest_number(&files, is_dir)
+        Ok(utils::name_with_largest_number(&files, is_dir))
     }
 }
 
@@ -88,19 +90,28 @@ impl BlockSource for S3BlockSource {
         .boxed()
     }
 
-    fn find_latest_block_number(&self) -> BoxFuture<'static, Option<u64>> {
+    fn find_latest_block_number(&self) -> BoxFuture<'static, eyre::Result<Option<u64>>> {
         let client = self.client.clone();
         let bucket = self.bucket.clone();
         async move {
-            let (_, first_level) =
-                Self::pick_path_with_highest_number(&client, &bucket, "", true).await?;
-            let (_, second_level) =
-                Self::pick_path_with_highest_number(&client, &bucket, &first_level, true).await?;
-            let (block_number, third_level) =
-                Self::pick_path_with_highest_number(&client, &bucket, &second_level, false).await?;
+            let Some((_, first_level)) =
+                Self::pick_path_with_highest_number(&client, &bucket, "", true).await?
+            else {
+                return Ok(None);
+            };
+            let Some((_, second_level)) =
+                Self::pick_path_with_highest_number(&client, &bucket, &first_level, true).await?
+            else {
+                return Ok(None);
+            };
+            let Some((block_number, third_level)) =
+                Self::pick_path_with_highest_number(&client, &bucket, &second_level, false).await?
+            else {
+                return Ok(None);
+            };
 
             info!("Latest block number: {} with path {}", block_number, third_level);
-            Some(block_number)
+            Ok(Some(block_number))
         }
         .boxed()
     }


### PR DESCRIPTION
Followup of #130 with some tweaks

## Summary
- Preserve latest-block discovery errors instead of collapsing them into `None`
- Add a shared retry loop for latest-block discovery and use it before the forkchoice trigger and block poller startup
- Keep retrying at the configured polling interval for the first 2s, then apply capped exponential backoff up to 30s
- Retry forkchoice trigger block fetches with the same delayed capped-backoff behavior and log failures with context
- Log block source fetch failures with context
- Make debug cutoff wait instead of repeatedly polling the cutoff block
- Add a regression test for latest-block retry recovery after an error and empty result

## Validation
- `cargo test -q wait_for_latest_block_number_retries_until_available`
- `cargo test -q pseudo_peer`
- `cargo check -q`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`
- Real node smoke test with `target/release/reth-hl` on the local mainnet snapshot using `AWS_PROFILE=aws`, `--s3`, and `--debug-cutoff-height 34922247`