### PR TITLE
Revert block source startup retry changes

### DIFF
--- a/src/node/network/mod.rs
+++ b/src/node/network/mod.rs
@@ -32,10 +32,9 @@ use reth_storage_api::BlockNumReader;
 use std::{
     net::{Ipv4Addr, SocketAddr},
     sync::Arc,
-    time::{Duration, Instant},
 };
 use tokio::sync::{Mutex, mpsc, oneshot};
-use tracing::{info, warn};
+use tracing::info;
 
 pub mod block_import;
 
@@ -289,11 +288,7 @@ where
                 // via a direct forkchoice update. This must happen before
                 // start_pseudo_peer (which never returns).
                 // get_by_number auto-indexes the block's hash AND parent hash.
-                let polling_interval = block_store.polling_interval();
-                let mut retry_interval = polling_interval;
-                let retry_started_at = Instant::now();
-                loop {
-                    let latest = block_store.wait_for_latest_block_number().await;
+                if let Some(latest) = block_store.find_latest_block_number().await {
                     match block_store.get_by_number(latest).await {
                         Ok(block) => {
                             let hash = block.hash();
@@ -304,22 +299,13 @@ where
                                 "Sending forkchoice trigger from block source"
                             );
                             let _ = fcu_trigger_tx.send(hash);
-                            break;
                         }
                         Err(e) => {
-                            warn!(
+                            info!(
                                 target: "reth::cli",
                                 %e,
-                                ?retry_interval,
-                                "Failed to read latest block for forkchoice trigger; retrying"
+                                "Failed to read latest block for forkchoice trigger"
                             );
-                            tokio::time::sleep(retry_interval).await;
-                            if retry_started_at.elapsed() >= Duration::from_secs(2) {
-                                retry_interval =
-                                    retry_interval.saturating_mul(2).min(Duration::from_secs(30));
-                            } else {
-                                retry_interval = polling_interval;
-                            }
                         }
                     }
                 }

--- a/src/pseudo_peer/block_store.rs
+++ b/src/pseudo_peer/block_store.rs
@@ -7,9 +7,9 @@ use reth_network::cache::LruMap;
 use std::{
     collections::HashMap,
     sync::Arc,
-    time::{Duration, Instant},
+    time::Duration,
 };
-use tracing::{info, warn};
+use tracing::info;
 
 /// Function that resolves a block hash to its number via the node's database.
 /// Returns `None` if the hash is not yet in the database (e.g. headers not synced yet).
@@ -18,8 +18,6 @@ pub type DbBlockNumberFn = Arc<dyn Fn(B256) -> Option<u64> + Send + Sync>;
 
 const BLOCK_CACHE_LIMIT: u32 = 100_000;
 const HASH_INDEX_LIMIT: u32 = 1_000_000;
-const LATEST_BLOCK_RETRY_BACKOFF_AFTER: Duration = Duration::from_secs(2);
-const LATEST_BLOCK_RETRY_MAX_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Unified block store that combines block content caching, hash↔number indexing,
 /// and database fallback into a single abstraction.
@@ -167,101 +165,11 @@ impl BlockStore {
 
     // --- Delegated block source methods ---
 
-    pub fn find_latest_block_number(&self) -> BoxFuture<'static, eyre::Result<Option<u64>>> {
+    pub fn find_latest_block_number(&self) -> BoxFuture<'static, Option<u64>> {
         self.source.find_latest_block_number()
-    }
-
-    pub async fn wait_for_latest_block_number(&self) -> u64 {
-        let polling_interval = self.polling_interval();
-        let mut retry_interval = self.polling_interval();
-        let retry_started_at = Instant::now();
-        loop {
-            match self.find_latest_block_number().await {
-                Ok(Some(block_number)) => return block_number,
-                Ok(None) => {
-                    warn!(
-                        ?retry_interval,
-                        "No latest block available from block source; retrying"
-                    );
-                }
-                Err(err) => {
-                    warn!(
-                        ?retry_interval,
-                        ?err,
-                        "Failed to find latest block number from block source; retrying"
-                    );
-                }
-            }
-
-            tokio::time::sleep(retry_interval).await;
-            if retry_started_at.elapsed() >= LATEST_BLOCK_RETRY_BACKOFF_AFTER {
-                retry_interval = retry_interval
-                    .saturating_mul(2)
-                    .min(LATEST_BLOCK_RETRY_MAX_INTERVAL);
-            } else {
-                retry_interval = polling_interval;
-            }
-        }
     }
 
     pub fn polling_interval(&self) -> Duration {
         self.source.polling_interval()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::{
-        node::types::BlockAndReceipts,
-        pseudo_peer::sources::{BlockSource, BlockSourceBoxed},
-    };
-    use futures::{FutureExt, future::BoxFuture};
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
-    #[derive(Debug)]
-    struct EventuallyLatestBlockSource {
-        attempts: Arc<AtomicUsize>,
-    }
-
-    impl BlockSource for EventuallyLatestBlockSource {
-        fn collect_block(&self, _height: u64) -> BoxFuture<'static, eyre::Result<BlockAndReceipts>> {
-            async { Err(eyre::eyre!("unused in this test")) }.boxed()
-        }
-
-        fn find_latest_block_number(&self) -> BoxFuture<'static, eyre::Result<Option<u64>>> {
-            let attempts = self.attempts.clone();
-            async move {
-                let attempt = attempts.fetch_add(1, Ordering::SeqCst);
-                match attempt {
-                    0 => Err(eyre::eyre!("temporary source error")),
-                    1 => Ok(None),
-                    _ => Ok(Some(42)),
-                }
-            }
-            .boxed()
-        }
-
-        fn recommended_chunk_size(&self) -> u64 {
-            1
-        }
-
-        fn polling_interval(&self) -> Duration {
-            Duration::from_millis(1)
-        }
-    }
-
-    #[tokio::test]
-    async fn wait_for_latest_block_number_retries_until_available() {
-        let attempts = Arc::new(AtomicUsize::new(0));
-        let source: BlockSourceBoxed = Arc::new(Box::new(EventuallyLatestBlockSource {
-            attempts: attempts.clone(),
-        }));
-        let store = BlockStore::new(source, None, 999);
-
-        let latest = store.wait_for_latest_block_number().await;
-
-        assert_eq!(latest, 42);
-        assert_eq!(attempts.load(Ordering::SeqCst), 3);
     }
 }

--- a/src/pseudo_peer/service.rs
+++ b/src/pseudo_peer/service.rs
@@ -63,14 +63,16 @@ impl BlockPoller {
         info!("Starting block poller");
 
         let polling_interval = block_store.polling_interval();
-        let mut next_block_number = block_store.wait_for_latest_block_number().await;
+        let mut next_block_number = block_store
+            .find_latest_block_number()
+            .await
+            .ok_or(eyre::eyre!("Failed to find latest block number"))?;
 
         loop {
-            if let Some(debug_cutoff_height) = debug_cutoff_height
-                && next_block_number > debug_cutoff_height
+            if let Some(debug_cutoff_height) = debug_cutoff_height &&
+                next_block_number > debug_cutoff_height
             {
-                tokio::time::sleep(polling_interval).await;
-                continue;
+                next_block_number = debug_cutoff_height;
             }
 
             match block_store.get_by_number(next_block_number).await {
@@ -78,14 +80,7 @@ impl BlockPoller {
                     block_tx.send((next_block_number, block)).await?;
                     next_block_number += 1;
                 }
-                Err(err) => {
-                    warn!(
-                        block_number = next_block_number,
-                        ?err,
-                        "Failed to fetch block from block source; retrying"
-                    );
-                    tokio::time::sleep(polling_interval).await;
-                }
+                Err(_) => tokio::time::sleep(polling_interval).await,
             }
         }
     }

--- a/src/pseudo_peer/sources/hl_node/mod.rs
+++ b/src/pseudo_peer/sources/hl_node/mod.rs
@@ -91,7 +91,7 @@ impl BlockSource for HlNodeBlockSource {
         })
     }
 
-    fn find_latest_block_number(&self) -> BoxFuture<'static, eyre::Result<Option<u64>>> {
+    fn find_latest_block_number(&self) -> BoxFuture<'static, Option<u64>> {
         let fallback = self.fallback.clone();
         let args = self.args.clone();
         Box::pin(async move {
@@ -106,7 +106,7 @@ impl BlockSource for HlNodeBlockSource {
             match FileOperations::read_last_block_from_file(&dir) {
                 Some((_, height)) => {
                     info!("Latest block number: {} with path {}", height, dir.display());
-                    Ok(Some(height))
+                    Some(height)
                 }
                 None => {
                     warn!(

--- a/src/pseudo_peer/sources/local.rs
+++ b/src/pseudo_peer/sources/local.rs
@@ -27,19 +27,15 @@ impl LocalBlockSource {
         Self { dir: dir.into(), metrics: LocalBlockSourceMetrics::default() }
     }
 
-    async fn pick_path_with_highest_number(
-        dir: PathBuf,
-        is_dir: bool,
-    ) -> eyre::Result<Option<(u64, String)>> {
-        let files = std::fs::read_dir(&dir)?.collect::<Vec<_>>();
+    async fn pick_path_with_highest_number(dir: PathBuf, is_dir: bool) -> Option<(u64, String)> {
+        let files = std::fs::read_dir(&dir).unwrap().collect::<Vec<_>>();
         let files = files
             .into_iter()
-            .filter_map(Result::ok)
-            .filter(|path| path.path().is_dir() == is_dir)
-            .map(|entry| entry.path().to_string_lossy().to_string())
+            .filter(|path| path.as_ref().unwrap().path().is_dir() == is_dir)
+            .map(|entry| entry.unwrap().path().to_string_lossy().to_string())
             .collect::<Vec<_>>();
 
-        Ok(utils::name_with_largest_number(&files, is_dir))
+        utils::name_with_largest_number(&files, is_dir)
     }
 }
 
@@ -62,27 +58,17 @@ impl BlockSource for LocalBlockSource {
         .boxed()
     }
 
-    fn find_latest_block_number(&self) -> BoxFuture<'static, eyre::Result<Option<u64>>> {
+    fn find_latest_block_number(&self) -> BoxFuture<'static, Option<u64>> {
         let dir = self.dir.clone();
         async move {
-            let Some((_, first_level)) =
-                Self::pick_path_with_highest_number(dir.clone(), true).await?
-            else {
-                return Ok(None);
-            };
-            let Some((_, second_level)) =
-                Self::pick_path_with_highest_number(dir.join(first_level), true).await?
-            else {
-                return Ok(None);
-            };
-            let Some((block_number, third_level)) =
-                Self::pick_path_with_highest_number(dir.join(second_level), false).await?
-            else {
-                return Ok(None);
-            };
+            let (_, first_level) = Self::pick_path_with_highest_number(dir.clone(), true).await?;
+            let (_, second_level) =
+                Self::pick_path_with_highest_number(dir.join(first_level), true).await?;
+            let (block_number, third_level) =
+                Self::pick_path_with_highest_number(dir.join(second_level), false).await?;
 
             info!("Latest block number: {} with path {}", block_number, third_level);
-            Ok(Some(block_number))
+            Some(block_number)
         }
         .boxed()
     }

--- a/src/pseudo_peer/sources/mod.rs
+++ b/src/pseudo_peer/sources/mod.rs
@@ -25,7 +25,7 @@ pub trait BlockSource: Send + Sync + std::fmt::Debug + Unpin + 'static {
     fn collect_block(&self, height: u64) -> BoxFuture<'static, eyre::Result<BlockAndReceipts>>;
 
     /// Finds the latest block number available from this source
-    fn find_latest_block_number(&self) -> BoxFuture<'static, eyre::Result<Option<u64>>>;
+    fn find_latest_block_number(&self) -> BoxFuture<'static, Option<u64>>;
 
     /// Returns the recommended chunk size for batch operations
     fn recommended_chunk_size(&self) -> u64;

--- a/src/pseudo_peer/sources/rpc.rs
+++ b/src/pseudo_peer/sources/rpc.rs
@@ -58,13 +58,13 @@ impl BlockSource for RpcBlockSource {
         .boxed()
     }
 
-    fn find_latest_block_number(&self) -> BoxFuture<'static, eyre::Result<Option<u64>>> {
+    fn find_latest_block_number(&self) -> BoxFuture<'static, Option<u64>> {
         let client = self.client.clone();
         async move {
             let result: Option<u64> =
-                client.request("hl_syncLatestBlockNumber", Vec::<u64>::new()).await?;
+                client.request("hl_syncLatestBlockNumber", Vec::<u64>::new()).await.ok()?;
             info!("Latest block number from remote: {:?}", result);
-            Ok(result)
+            result
         }
         .boxed()
     }

--- a/src/pseudo_peer/sources/s3.rs
+++ b/src/pseudo_peer/sources/s3.rs
@@ -39,30 +39,28 @@ impl S3BlockSource {
         bucket: &str,
         dir: &str,
         is_dir: bool,
-    ) -> eyre::Result<Option<(u64, String)>> {
+    ) -> Option<(u64, String)> {
         let request = client
             .list_objects()
             .bucket(bucket)
             .prefix(dir)
             .delimiter("/")
             .request_payer(RequestPayer::Requester);
-        let response = request.send().await?;
+        let response = request.send().await.ok()?;
         let files: Vec<String> = if is_dir {
             response
-                .common_prefixes
-                .unwrap_or_default()
+                .common_prefixes?
                 .iter()
-                .filter_map(|object| object.prefix.as_ref().map(ToString::to_string))
+                .map(|object| object.prefix.as_ref().unwrap().to_string())
                 .collect()
         } else {
             response
-                .contents
-                .unwrap_or_default()
+                .contents?
                 .iter()
-                .filter_map(|object| object.key.as_ref().map(ToString::to_string))
+                .map(|object| object.key.as_ref().unwrap().to_string())
                 .collect()
         };
-        Ok(utils::name_with_largest_number(&files, is_dir))
+        utils::name_with_largest_number(&files, is_dir)
     }
 }
 
@@ -90,28 +88,19 @@ impl BlockSource for S3BlockSource {
         .boxed()
     }
 
-    fn find_latest_block_number(&self) -> BoxFuture<'static, eyre::Result<Option<u64>>> {
+    fn find_latest_block_number(&self) -> BoxFuture<'static, Option<u64>> {
         let client = self.client.clone();
         let bucket = self.bucket.clone();
         async move {
-            let Some((_, first_level)) =
-                Self::pick_path_with_highest_number(&client, &bucket, "", true).await?
-            else {
-                return Ok(None);
-            };
-            let Some((_, second_level)) =
-                Self::pick_path_with_highest_number(&client, &bucket, &first_level, true).await?
-            else {
-                return Ok(None);
-            };
-            let Some((block_number, third_level)) =
-                Self::pick_path_with_highest_number(&client, &bucket, &second_level, false).await?
-            else {
-                return Ok(None);
-            };
+            let (_, first_level) =
+                Self::pick_path_with_highest_number(&client, &bucket, "", true).await?;
+            let (_, second_level) =
+                Self::pick_path_with_highest_number(&client, &bucket, &first_level, true).await?;
+            let (block_number, third_level) =
+                Self::pick_path_with_highest_number(&client, &bucket, &second_level, false).await?;
 
             info!("Latest block number: {} with path {}", block_number, third_level);
-            Ok(Some(block_number))
+            Some(block_number)
         }
         .boxed()
     }


### PR DESCRIPTION
## Summary
- Reverts PRs #130 and #134 which added retry logic for block source startup
- Restores the original block source startup behavior across 8 files

## Test plan
- [ ] Verify node starts and syncs blocks without retry logic
- [ ] Confirm no regressions in block source initialization

🤖 Generated with [Claude Code](https://claude.com/claude-code)