### PR TITLE
fix: Fix testnet token mapping and support tunable options (backoff, custom urls)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9354,6 +9354,7 @@ dependencies = [
  "auto_impl",
  "aws-config",
  "aws-sdk-s3",
+ "backon",
  "bytes",
  "cfg-if",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,7 @@ tracing = { version = "0.1.0", default-features = false }
 rmp-serde = "1.3"
 lz4_flex = "0.11"
 ureq = "3.0.12"
+backon = { version = "1.5.2", default-features = false, features = ["std-blocking-sleep", "tokio-sleep"] }
 aws-sdk-s3 = "1.93.0"
 aws-config = "1.8.0"
 rayon = "1.7"

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use reth_hl::{
         HlNode,
         cli::{Cli, HlNodeArgs},
         rpc::precompile::{HlBlockPrecompileApiServer, HlBlockPrecompileExt},
-        spot_meta::init as spot_meta_init,
+        spot_meta::{self, init as spot_meta_init},
         storage::tables::Tables,
         types::set_spot_metadata_db,
     },
@@ -48,6 +48,15 @@ fn main() -> eyre::Result<()> {
     Cli::<HlChainSpecParser, HlNodeArgs>::parse().run(
         |builder: WithLaunchContext<NodeBuilder<Arc<DatabaseEnv>, HlChainSpec>>,
          ext: HlNodeArgs| async move {
+            // Apply spot-meta CLI overrides before anything fetches metadata.
+            spot_meta::set_spot_meta_url(ext.spot_meta_url.clone());
+            let mut spot_meta_overrides = std::collections::BTreeMap::new();
+            for entry in &ext.spot_meta_overrides {
+                let (address, index) = spot_meta::parse_spot_meta_override(entry)?;
+                spot_meta_overrides.insert(address, index);
+            }
+            spot_meta::add_spot_meta_overrides(spot_meta_overrides);
+
             let default_upstream_rpc_url = builder.config().chain.official_rpc_url();
 
             let enable_sync_server = ext.enable_sync_server;

--- a/src/node/cli.rs
+++ b/src/node/cli.rs
@@ -104,6 +104,21 @@ pub struct HlNodeArgs {
     /// that use --block-source=rpc://... to sync from this node.
     #[arg(long, env = "ENABLE_SYNC_SERVER")]
     pub enable_sync_server: bool,
+
+    /// Custom API URL used when fetching spot metadata.
+    ///
+    /// Defaults to Hyperliquid's mainnet/testnet info endpoint based on the chain id.
+    /// Useful for pointing at a proxy or a private archive of the spot-meta response.
+    #[arg(long = "spot-meta.url", env = "SPOT_META_URL")]
+    pub spot_meta_url: Option<String>,
+
+    /// Manual spot-metadata overrides as `address:index` pairs.
+    ///
+    /// Applied on top of (and winning over) the fetched metadata and built-in patches.
+    /// May be repeated or comma-separated, e.g.
+    /// `--spot-meta.override 0xabc...:0 --spot-meta.override 0xdef...:3`.
+    #[arg(long = "spot-meta.override", env = "SPOT_META_OVERRIDES", value_delimiter = ',')]
+    pub spot_meta_overrides: Vec<String>,
 }
 
 /// The main reth_hl cli interface.

--- a/src/node/cli.rs
+++ b/src/node/cli.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     pseudo_peer::BlockSourceArgs,
 };
-use clap::{Args, Parser};
+use clap::{Args, Parser, Subcommand};
 use reth::{
     CliRunner,
     args::{DatabaseArgs, DatadirArgs, LogArgs},
@@ -121,6 +121,49 @@ pub struct HlNodeArgs {
     pub spot_meta_overrides: Vec<String>,
 }
 
+/// reth_hl cli commands: the built-in reth subcommands plus reth_hl-specific extras.
+#[derive(Debug, Subcommand)]
+pub enum HlCommands<
+    Spec: ChainSpecParser = HlChainSpecParser,
+    Ext: clap::Args + fmt::Debug = HlNodeArgs,
+> {
+    /// Built-in reth subcommands (node, init, init-state, db, ...).
+    #[command(flatten)]
+    Reth(Commands<Spec, Ext>),
+
+    /// Clear the spot metadata table from the database (debug utility).
+    ///
+    /// Removes all stored spot metadata so it will be re-fetched from the API on
+    /// the next run. Useful after a bad fetch or to re-apply `--spot-meta.*` overrides.
+    #[command(name = "clear-spot-meta")]
+    ClearSpotMeta(ClearSpotMetaCommand<Spec>),
+}
+
+impl<C: ChainSpecParser, Ext: clap::Args + fmt::Debug> HlCommands<C, Ext> {
+    /// Returns the underlying chain being used for commands, if any.
+    pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
+        match self {
+            Self::Reth(command) => command.chain_spec(),
+            Self::ClearSpotMeta(command) => Some(&command.env.chain),
+        }
+    }
+}
+
+/// Clear the spot metadata table from the database.
+#[derive(Debug, Parser)]
+pub struct ClearSpotMetaCommand<C: ChainSpecParser> {
+    #[command(flatten)]
+    env: EnvironmentArgs<C>,
+}
+
+impl<C: ChainSpecParser<ChainSpec = HlChainSpec>> ClearSpotMetaCommand<C> {
+    fn execute(self) -> eyre::Result<()> {
+        let data_dir = self.env.datadir.clone().resolve_datadir(self.env.chain.chain());
+        let db_path = data_dir.db();
+        spot_meta_init::clear_spot_metadata(db_path, self.env.db.database_args())
+    }
+}
+
 /// The main reth_hl cli interface.
 ///
 /// This is the entrypoint to the executable.
@@ -130,7 +173,7 @@ pub struct Cli<Spec: ChainSpecParser = HlChainSpecParser, Ext: clap::Args + fmt:
 {
     /// The command to run
     #[command(subcommand)]
-    pub command: Commands<Spec, Ext>,
+    pub command: HlCommands<Spec, Ext>,
 
     #[command(flatten)]
     logs: LogArgs,
@@ -180,7 +223,14 @@ where
             (HlEvmConfig::new(spec.clone()), Arc::new(HlConsensus::new(spec)))
         };
 
-        match self.command {
+        // Handle reth_hl-specific commands; otherwise fall through to the built-in
+        // reth subcommands below.
+        let command = match self.command {
+            HlCommands::Reth(command) => command,
+            HlCommands::ClearSpotMeta(command) => return command.execute(),
+        };
+
+        match command {
             Commands::Node(command) => runner.run_command_until_exit(|ctx| {
                 // NOTE: This is for one time migration around Oct 10 upgrade:
                 // It's not necessary anymore, an environment variable gate is added here.

--- a/src/node/spot_meta/init.rs
+++ b/src/node/spot_meta/init.rs
@@ -5,7 +5,10 @@ use crate::node::{
 };
 use alloy_primitives::Address;
 use reth_db::{DatabaseEnv, cursor::DbCursorRO};
-use reth_db_api::{Database, transaction::DbTx};
+use reth_db_api::{
+    Database,
+    transaction::{DbTx, DbTxMut},
+};
 use std::{collections::BTreeMap, sync::Arc};
 use tracing::info;
 
@@ -93,5 +96,24 @@ pub fn init_spot_metadata(
     reth_compat::store_spot_metadata(&db, &metadata)?;
 
     info!("Successfully fetched and stored spot metadata for chain {}", chain_id);
+    Ok(())
+}
+
+/// Clear the spot metadata table from the database.
+///
+/// Debug utility: removes all stored spot metadata so it will be re-fetched from
+/// the API on the next run (e.g. after a bad fetch or to pick up overrides).
+pub fn clear_spot_metadata(
+    db_path: impl AsRef<std::path::Path>,
+    db_args: reth_db::mdbx::DatabaseArguments,
+) -> eyre::Result<()> {
+    let db = Arc::new(reth_db::open_db(db_path.as_ref(), db_args)?);
+
+    db.update(|tx| -> Result<(), reth_db::DatabaseError> {
+        tx.clear::<tables::SpotMetadata>()?;
+        Ok(())
+    })??;
+
+    info!("Cleared spot metadata table");
     Ok(())
 }

--- a/src/node/spot_meta/mod.rs
+++ b/src/node/spot_meta/mod.rs
@@ -1,9 +1,76 @@
 use alloy_primitives::{Address, U256};
+use backon::{BlockingRetryable, ExponentialBuilder};
 use eyre::{Error, Result};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, str::FromStr, sync::RwLock};
+use tracing::warn;
 
 use crate::chainspec::{MAINNET_CHAIN_ID, TESTNET_CHAIN_ID};
+
+/// CLI/env override for the spot-meta API URL. When set, it takes precedence over
+/// the chain-default URL. Set once at startup; falls back to `SPOT_META_URL` env var.
+static URL_OVERRIDE: RwLock<Option<String>> = RwLock::new(None);
+
+/// CLI/env supplied manual `address -> spot index` mappings applied on top of the
+/// fetched metadata (in addition to the built-in testnet patch).
+static MANUAL_OVERRIDES: RwLock<BTreeMap<Address, u64>> = RwLock::new(BTreeMap::new());
+
+/// Set a custom spot-meta API URL (e.g. from `--spot-meta-url`). `None` clears it.
+pub fn set_spot_meta_url(url: Option<String>) {
+    *URL_OVERRIDE.write().unwrap() = url.filter(|u| !u.is_empty());
+}
+
+/// Add manual `address -> spot index` overrides (e.g. from `--spot-meta-override`).
+pub fn add_spot_meta_overrides(overrides: BTreeMap<Address, u64>) {
+    MANUAL_OVERRIDES.write().unwrap().extend(overrides);
+}
+
+/// Parse a single `address:index` override string into its components.
+pub fn parse_spot_meta_override(s: &str) -> Result<(Address, u64)> {
+    let (addr, index) = s
+        .split_once(':')
+        .ok_or_else(|| Error::msg(format!("invalid override '{s}', expected 'address:index'")))?;
+    let address = Address::from_str(addr.trim())
+        .map_err(|e| Error::msg(format!("invalid address in override '{s}': {e}")))?;
+    let index = index
+        .trim()
+        .parse::<u64>()
+        .map_err(|e| Error::msg(format!("invalid index in override '{s}': {e}")))?;
+    Ok((address, index))
+}
+
+/// Resolve the API URL: CLI/env override first, then the chain default.
+fn resolve_url(chain_id: u64) -> Result<String> {
+    if let Some(url) = URL_OVERRIDE.read().unwrap().clone() {
+        return Ok(url);
+    }
+    if let Ok(url) = std::env::var("SPOT_META_URL")
+        && !url.is_empty()
+    {
+        return Ok(url);
+    }
+    match chain_id {
+        MAINNET_CHAIN_ID => Ok("https://api.hyperliquid.xyz/info".to_string()),
+        TESTNET_CHAIN_ID => Ok("https://api.hyperliquid-testnet.xyz/info".to_string()),
+        _ => Err(Error::msg("unknown chain id")),
+    }
+}
+
+/// Collect manual overrides from the global store and the `SPOT_META_OVERRIDES` env var.
+fn collect_manual_overrides() -> BTreeMap<Address, u64> {
+    let mut overrides = MANUAL_OVERRIDES.read().unwrap().clone();
+    if let Ok(raw) = std::env::var("SPOT_META_OVERRIDES") {
+        for entry in raw.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+            match parse_spot_meta_override(entry) {
+                Ok((addr, index)) => {
+                    overrides.insert(addr, index);
+                }
+                Err(e) => warn!("Ignoring invalid SPOT_META_OVERRIDES entry: {e}"),
+            }
+        }
+    }
+    overrides
+}
 
 pub mod init;
 mod patch;
@@ -40,17 +107,23 @@ impl SpotId {
 }
 
 fn fetch_spot_meta(chain_id: u64) -> Result<SpotMeta> {
-    let url = match chain_id {
-        MAINNET_CHAIN_ID => "https://api.hyperliquid.xyz/info",
-        TESTNET_CHAIN_ID => "https://api.hyperliquid-testnet.xyz/info",
-        _ => return Err(Error::msg("unknown chain id")),
+    let url = resolve_url(chain_id)?;
+
+    let fetch = || -> Result<SpotMeta> {
+        let response = ureq::post(&url)
+            .header("Content-Type", "application/json")
+            .send(serde_json::json!({"type": "spotMeta"}).to_string())?
+            .into_body()
+            .read_to_string()?;
+        Ok(serde_json::from_str(&response)?)
     };
-    let response = ureq::post(url)
-        .header("Content-Type", "application/json")
-        .send(serde_json::json!({"type": "spotMeta"}).to_string())?
-        .into_body()
-        .read_to_string()?;
-    Ok(serde_json::from_str(&response)?)
+
+    fetch
+        .retry(ExponentialBuilder::default().without_max_times().with_jitter())
+        .notify(|err, dur| {
+            warn!("Failed to fetch spot metadata: {err}. Retrying in {dur:?}");
+        })
+        .call()
 }
 
 pub(crate) fn erc20_contract_to_spot_token(chain_id: u64) -> Result<BTreeMap<Address, SpotId>> {
@@ -64,6 +137,12 @@ pub(crate) fn erc20_contract_to_spot_token(chain_id: u64) -> Result<BTreeMap<Add
 
     if chain_id == TESTNET_CHAIN_ID {
         patch::patch_testnet_spot_meta(&mut map);
+    }
+
+    // Apply CLI/env manual overrides last so they win over both the fetched
+    // metadata and the built-in patches.
+    for (address, index) in collect_manual_overrides() {
+        map.insert(address, SpotId { index });
     }
 
     Ok(map)

--- a/src/node/spot_meta/patch.rs
+++ b/src/node/spot_meta/patch.rs
@@ -5,4 +5,5 @@ use std::collections::BTreeMap;
 /// Testnet-specific fix for #67
 pub(super) fn patch_testnet_spot_meta(map: &mut BTreeMap<Address, SpotId>) {
     map.insert(address!("0xd9cbec81df392a88aeff575e962d149d57f4d6bc"), SpotId { index: 0 });
+    map.insert(address!("0x2b3370ee501b4a559b57d449569354196457d8ab"), SpotId { index: 0 });
 }

--- a/src/node/types/reth_compat.rs
+++ b/src/node/types/reth_compat.rs
@@ -132,6 +132,10 @@ static SPOT_EVM_MAP: LazyLock<Arc<RwLock<BTreeMap<Address, SpotId>>>> =
 // Optional database handle for persisting on-demand fetches
 static DB_HANDLE: LazyLock<Mutex<Option<Arc<DatabaseEnv>>>> = LazyLock::new(|| Mutex::new(None));
 
+// Single-flight guard: ensures only one thread fetches spot metadata from the
+// API on a cache miss, so a thundering herd of misses produces one request.
+static SPOT_FETCH_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
 /// Set the database handle for persisting spot metadata
 pub fn set_spot_metadata_db(db: Arc<DatabaseEnv>) {
     *DB_HANDLE.lock().unwrap() = Some(db);
@@ -190,7 +194,17 @@ fn system_tx_to_reth_transaction(transaction: &SystemTx, chain_id: u64) -> TxSig
                 break spot.to_s();
             }
 
-            // Cache miss - fetch from API, update cache, and persist to database
+            // Cache miss - single-flight the API fetch so concurrent misses don't
+            // each hit the API. Only the thread holding SPOT_FETCH_LOCK fetches;
+            // the rest block here and re-check the cache once it's released.
+            let _fetch_guard = SPOT_FETCH_LOCK.lock().unwrap();
+
+            // Double-checked: another thread may have populated the cache while we
+            // waited for the fetch lock.
+            if SPOT_EVM_MAP.read().unwrap().contains_key(&to) {
+                continue;
+            }
+
             info!("Contract not found: {to:?} from spot mapping, fetching from API...");
             let metadata = erc20_contract_to_spot_token(chain_id).unwrap();
             *SPOT_EVM_MAP.write().unwrap() = metadata.clone();


### PR DESCRIPTION
Fix mapping, and also add those options for making this tunable.

```
reth-hl node ... \
  --spot-meta.url https://my-proxy.internal/info \
  --spot-meta.override 0xd9cbec81df392a88aeff575e962d149d57f4d6bc:0 \
  --spot-meta.override 0x2b3370ee501b4a559b57d449569354196457d8ab:0
```

and to reset overrides persisting in cache,

```
reth-hl clear-spot-meta
```