### PR TITLE
fix(testnet): recover real system-tx sender

### DIFF
--- a/src/node/types/mod.rs
+++ b/src/node/types/mod.rs
@@ -17,6 +17,7 @@ pub type ReadPrecompileCall = (Address, Vec<(ReadPrecompileInput, ReadPrecompile
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Default, Hash)]
 pub struct ReadPrecompileCalls(pub Vec<ReadPrecompileCall>);
 
+mod patch;
 pub(crate) mod reth_compat;
 
 // Re-export spot metadata functions

--- a/src/node/types/patch.rs
+++ b/src/node/types/patch.rs
@@ -1,0 +1,141 @@
+//! Testnet patches for the reth block conversion in [`super::reth_compat`].
+use super::LegacyReceipt;
+use crate::chainspec::TESTNET_CHAIN_ID;
+use alloy_primitives::{Address, B256, U256, address, b256};
+
+/// `keccak256("Transfer(address,address,uint256)")` — the ERC-20 `Transfer` topic.
+const ERC20_TRANSFER_TOPIC: B256 =
+    b256!("ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef");
+
+/// Token contract whose testnet system transactions need real-sender recovery.
+///
+/// Its synthetic spot-index sender (`s_to_address(to_s(0))` == `0x2000…0000`)
+/// collides across holders, so the interleaved per-sender nonces only validate
+/// once the true `msg.sender` is recovered from the receipt.
+const SENDER_RECOVERY_TOKEN: Address = address!("0x2b3370ee501b4a559b57d449569354196457d8ab");
+
+/// First testnet block at which the recovery applies.
+const SENDER_RECOVERY_FROM_BLOCK: u64 = 55231857;
+
+/// Recover the real `msg.sender` of a token system transaction from its receipt,
+/// restricted to the minimal known-affected set (testnet, one token, at or after
+/// the first affected block). Returns `None` everywhere else so the caller falls
+/// back to the legacy synthetic-sender (`to_s`) encoding.
+///
+/// For an ERC-20 transfer the caller is observable as the `from` topic of the
+/// `Transfer` event emitted by the token (`to`) contract.
+pub(super) fn recover_testnet_system_tx_sender(
+    chain_id: u64,
+    block_number: u64,
+    token: Address,
+    receipt: Option<&LegacyReceipt>,
+) -> Option<Address> {
+    if chain_id != TESTNET_CHAIN_ID
+        || block_number < SENDER_RECOVERY_FROM_BLOCK
+        || token != SENDER_RECOVERY_TOKEN
+    {
+        return None;
+    }
+    let sender = receipt?.logs.iter().find_map(|log| {
+        let topics = log.data.topics();
+        (log.address == token
+            && topics.first() == Some(&ERC20_TRANSFER_TOPIC)
+            && topics.len() >= 2)
+            .then(|| Address::from_word(topics[1]))
+    })?;
+    // `s_to_address` treats `s == 1` as a sentinel (mapping it to 0x2222…2222), so a
+    // sender of 0x00..01 cannot be round-tripped through `s`. Decline it (fall back
+    // to the legacy encoding) rather than mis-recovering.
+    (U256::from_be_slice(sender.as_slice()) != U256::ONE).then_some(sender)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::node::types::LegacyReceipt;
+    use alloy_consensus::TxType;
+    use alloy_primitives::{Bytes, Log, LogData};
+    use reth_ethereum_primitives::EthereumReceipt;
+
+    const HOLDER_A: Address = address!("f9b10ef826e9aa275f1813034e3bd9b80224e535");
+    const HOLDER_B: Address = address!("0b80659a4076e9e93c7dbe0f10675a16a3e5c206");
+    const OTHER_TOKEN: Address = address!("d9cbec81df392a88aeff575e962d149d57f4d6bc");
+
+    fn transfer_log(emitter: Address, from: Address, to: Address) -> Log {
+        Log {
+            address: emitter,
+            data: LogData::new_unchecked(
+                vec![ERC20_TRANSFER_TOPIC, from.into_word(), to.into_word()],
+                U256::from(1_000u64).to_be_bytes::<32>().to_vec().into(),
+            ),
+        }
+    }
+
+    fn receipt(logs: Vec<Log>) -> LegacyReceipt {
+        EthereumReceipt { tx_type: TxType::Legacy, success: true, cumulative_gas_used: 0, logs }
+            .into()
+    }
+
+    fn recover(chain_id: u64, block: u64, token: Address, logs: Vec<Log>) -> Option<Address> {
+        let r = receipt(logs);
+        recover_testnet_system_tx_sender(chain_id, block, token, Some(&r))
+    }
+
+    #[test]
+    fn recovers_sender_for_targeted_token() {
+        let logs = vec![transfer_log(SENDER_RECOVERY_TOKEN, HOLDER_B, HOLDER_A)];
+        assert_eq!(
+            recover(TESTNET_CHAIN_ID, SENDER_RECOVERY_FROM_BLOCK, SENDER_RECOVERY_TOKEN, logs),
+            Some(HOLDER_B)
+        );
+    }
+
+    #[test]
+    fn declines_outside_the_minimal_set() {
+        let log = || vec![transfer_log(SENDER_RECOVERY_TOKEN, HOLDER_B, HOLDER_A)];
+        // wrong chain
+        assert_eq!(recover(999, SENDER_RECOVERY_FROM_BLOCK, SENDER_RECOVERY_TOKEN, log()), None);
+        // before the first affected block
+        assert_eq!(
+            recover(TESTNET_CHAIN_ID, SENDER_RECOVERY_FROM_BLOCK - 1, SENDER_RECOVERY_TOKEN, log()),
+            None
+        );
+        // a different (non-targeted) token, even though it emits a Transfer
+        let other = vec![transfer_log(OTHER_TOKEN, HOLDER_B, HOLDER_A)];
+        assert_eq!(recover(TESTNET_CHAIN_ID, SENDER_RECOVERY_FROM_BLOCK, OTHER_TOKEN, other), None);
+    }
+
+    #[test]
+    fn ignores_unrelated_logs() {
+        // Transfer emitted by some other contract (not the token `to`).
+        let foreign = vec![transfer_log(OTHER_TOKEN, HOLDER_B, HOLDER_A)];
+        assert_eq!(
+            recover(TESTNET_CHAIN_ID, SENDER_RECOVERY_FROM_BLOCK, SENDER_RECOVERY_TOKEN, foreign),
+            None
+        );
+        // Non-Transfer event (wrong topic0) from the token.
+        let approval = Log {
+            address: SENDER_RECOVERY_TOKEN,
+            data: LogData::new_unchecked(
+                vec![B256::ZERO, HOLDER_B.into_word(), HOLDER_A.into_word()],
+                Bytes::new(),
+            ),
+        };
+        assert_eq!(
+            recover(TESTNET_CHAIN_ID, SENDER_RECOVERY_FROM_BLOCK, SENDER_RECOVERY_TOKEN, vec![
+                approval
+            ]),
+            None
+        );
+    }
+
+    #[test]
+    fn guards_against_degenerate_one_address() {
+        let one = address!("0000000000000000000000000000000000000001");
+        let logs = vec![transfer_log(SENDER_RECOVERY_TOKEN, one, HOLDER_A)];
+        assert_eq!(
+            recover(TESTNET_CHAIN_ID, SENDER_RECOVERY_FROM_BLOCK, SENDER_RECOVERY_TOKEN, logs),
+            None
+        );
+    }
+}

--- a/src/node/types/reth_compat.rs
+++ b/src/node/types/reth_compat.rs
@@ -12,6 +12,7 @@ use std::{
 };
 use tracing::info;
 
+use super::patch::recover_testnet_system_tx_sender;
 use crate::{
     HlBlock, HlBlockBody, HlHeader,
     node::{
@@ -179,14 +180,29 @@ fn persist_spot_metadata_to_db(metadata: &BTreeMap<Address, SpotId>) {
     }
 }
 
-fn system_tx_to_reth_transaction(transaction: &SystemTx, chain_id: u64) -> TxSigned {
+fn system_tx_to_reth_transaction(
+    transaction: &SystemTx,
+    chain_id: u64,
+    block_number: u64,
+) -> TxSigned {
     let Transaction::Legacy(tx) = &transaction.tx else {
         panic!("Unexpected transaction type");
     };
     let TxKind::Call(to) = tx.to else {
         panic!("Unexpected contract creation");
     };
-    let s = if tx.input.is_empty() {
+    let s = if let Some(sender) = recover_testnet_system_tx_sender(
+        chain_id,
+        block_number,
+        to,
+        transaction.receipt.as_ref(),
+    ) {
+        // Encode the real `msg.sender` (recovered from the ERC-20 `Transfer` log) into
+        // `s`, so that `s_to_address(s)` recovers the actual holder. This lets each
+        // sender's nonces validate normally, removing the need to disable nonce checks
+        // for these system transactions.
+        U256::from_be_slice(sender.as_slice())
+    } else if tx.input.is_empty() {
         U256::from(0x1)
     } else {
         loop {
@@ -228,7 +244,10 @@ impl SealedBlock {
         system_txs.retain(|tx| tx.receipt.is_some());
 
         let mut merged_txs = vec![];
-        merged_txs.extend(system_txs.iter().map(|tx| system_tx_to_reth_transaction(tx, chain_id)));
+        let block_number = self.header.header.number;
+        merged_txs.extend(
+            system_txs.iter().map(|tx| system_tx_to_reth_transaction(tx, chain_id, block_number)),
+        );
         merged_txs.extend(self.body.transactions.iter().map(|tx| tx.to_reth_transaction()));
 
         let mut merged_receipts = vec![];
@@ -255,5 +274,72 @@ impl SealedBlock {
             ),
             body: block_body,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chainspec::TESTNET_CHAIN_ID;
+    use alloy_consensus::{Transaction as _, TxType};
+    use alloy_primitives::{Log, LogData, address, b256};
+    use reth_ethereum_primitives::EthereumReceipt;
+    use reth_primitives_traits::SignerRecoverable;
+
+    // The single token targeted by the testnet sender-recovery patch.
+    const TOKEN: Address = address!("2b3370ee501b4a559b57d449569354196457d8ab");
+    const FROM_BLOCK: u64 = 55231857;
+    const HOLDER_A: Address = address!("f9b10ef826e9aa275f1813034e3bd9b80224e535");
+    const HOLDER_B: Address = address!("0b80659a4076e9e93c7dbe0f10675a16a3e5c206");
+
+    fn transfer_log(from: Address, to: Address) -> Log {
+        Log {
+            address: TOKEN,
+            data: LogData::new_unchecked(
+                vec![
+                    b256!("ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"),
+                    from.into_word(),
+                    to.into_word(),
+                ],
+                U256::from(1_000u64).to_be_bytes::<32>().to_vec().into(),
+            ),
+        }
+    }
+
+    fn system_tx(from: Address, to: Address, nonce: u64) -> SystemTx {
+        let receipt: LegacyReceipt = EthereumReceipt {
+            tx_type: TxType::Legacy,
+            success: true,
+            cumulative_gas_used: 0,
+            logs: vec![transfer_log(from, to)],
+        }
+        .into();
+        SystemTx {
+            tx: Transaction::Legacy(TxLegacy {
+                chain_id: Some(TESTNET_CHAIN_ID),
+                nonce,
+                gas_price: 0,
+                gas_limit: 200_000,
+                to: TxKind::Call(to),
+                value: U256::ZERO,
+                // transfer(address,uint256) selector; input non-empty
+                input: Bytes::from_static(&[0xa9, 0x05, 0x9c, 0xbb]),
+            }),
+            receipt: Some(receipt),
+        }
+    }
+
+    #[test]
+    fn testnet_conversion_recovers_real_holder() {
+        // Full path: testnet system_tx -> synthetic signature -> recover_signer == real sender.
+        // Both interleaved holders recover independently (the synthetic collision is gone).
+        let tx = system_tx(HOLDER_B, TOKEN, 1);
+        let signed = system_tx_to_reth_transaction(&tx, TESTNET_CHAIN_ID, FROM_BLOCK);
+        assert_eq!(signed.gas_price(), Some(0)); // recognised as a system tx
+        assert_eq!(signed.recover_signer().unwrap(), HOLDER_B);
+
+        let tx2 = system_tx(HOLDER_A, TOKEN, 0);
+        let signed2 = system_tx_to_reth_transaction(&tx2, TESTNET_CHAIN_ID, FROM_BLOCK);
+        assert_eq!(signed2.recover_signer().unwrap(), HOLDER_A);
     }
 }


### PR DESCRIPTION
This PR is scoped as temporary testnet patch that handles subset of testnet transactions\*. Different fixes may follow in future, but the current PR handles all known cases.

For these transactions, recover the real `msg.sender` from the receipt's ERC-20 `Transfer` `from` topic and encode it into `s`, so `s_to_address` returns the actual holder and nonces validate normally (check stays enabled).

\*: testnet, token `0x2b3370ee…d8ab`, blocks ≥ 55231857. Everything else keeps the existing semantics.